### PR TITLE
Fix license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version='3.0.0',
     author='Yelp, Inc.',
     author_email='opensource+pyramid-hypernova@yelp.com',
-    license='Copyright Yelp 2018',
+    license='MIT',
     url='https://github.com/Yelp/pyramid-hypernova',
     description="A Python client for Airbnb's Hypernova server, for use with the Pyramid web framework.",
     classifiers=[
@@ -19,6 +19,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'License :: OSI Approved :: MIT License',
     ],
     install_requires=[
         'fido',


### PR DESCRIPTION
"Copyright Yelp 2018" isn't a license :P

https://packaging.python.org/tutorials/distributing-packages/#license