### PR TITLE
Add support for custom JSON encoder

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,7 @@ source =
 omit =
     .tox/*
     /usr/*
-    /testing/*
+    testing/*
     setup.py
 
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ source =
 omit =
     .tox/*
     /usr/*
+    /testing/*
     setup.py
 
 [report]

--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import sys
 import traceback
 import uuid
+from json import JSONEncoder
 
 import fido
 from fido.exceptions import NetworkError
@@ -56,12 +57,12 @@ def create_job_groups(jobs, max_batch_size):
 
 class BatchRequest(object):
 
-    def __init__(self, batch_url, plugin_controller, json_encoder, max_batch_size=None):
+    def __init__(self, batch_url, plugin_controller, max_batch_size=None, json_encoder=JSONEncoder()):
         self.batch_url = batch_url
         self.jobs = {}
         self.plugin_controller = plugin_controller
-        self.json_encoder = json_encoder
         self.max_batch_size = max_batch_size
+        self.json_encoder = json_encoder
 
     def render(self, name, data):
         identifier = str(uuid.uuid4())

--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -2,7 +2,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import json
 import sys
 import traceback
 import uuid
@@ -154,7 +153,8 @@ class BatchRequest(object):
             futures = []
 
             for job_group in job_groups:
-                job_bytes = json.dumps(create_jobs_payload(job_group), cls=self.json_encoder).encode('utf-8')
+                job_str = self.json_encoder.encode(create_jobs_payload(job_group))
+                job_bytes = job_str.encode('utf-8')
                 futures.append(
                     fido.fetch(
                         url=self.batch_url,

--- a/pyramid_hypernova/rendering.py
+++ b/pyramid_hypernova/rendering.py
@@ -37,19 +37,19 @@ FALLBACK_ERROR = dedent('''
 ''')  # noqa: ignore=E501
 
 
-def encode(data):
-    text = json.dumps(data)
+def encode(data, json_encoder):
+    text = json.dumps(data, cls=json_encoder)
     # NOTE: we don't escape all html characters, because hypernova.decode will
     # only resolve &amp; and &gt;. This should be safe though, because the
     # encoded JSON always appears within an HTML comment.
     return text.replace('&', '&amp;').replace('>', '&gt;')
 
 
-def render_blank_markup(identifier, job, throw_client_error):
+def render_blank_markup(identifier, job, throw_client_error, json_encoder):
     """This will be called as a fallback when server-side rendering fails."""
     # Hypernova server strips out non-word characters from the name
     key = re.sub(r'\W', '', job.name)
-    encoded_data = encode(job.data)
+    encoded_data = encode(job.data, json_encoder)
     blank_markup = BLANK_MARKUP_TEMPLATE.format(
         key=key,
         identifier=identifier,

--- a/pyramid_hypernova/rendering.py
+++ b/pyramid_hypernova/rendering.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import json
 import re
 from textwrap import dedent
 
@@ -38,7 +37,7 @@ FALLBACK_ERROR = dedent('''
 
 
 def encode(data, json_encoder):
-    text = json.dumps(data, cls=json_encoder)
+    text = json_encoder.encode(data)
     # NOTE: we don't escape all html characters, because hypernova.decode will
     # only resolve &amp; and &gt;. This should be safe though, because the
     # encoded JSON always appears within an HTML comment.

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -24,9 +24,9 @@ def hypernova_tween_factory(handler, registry):
 
     def hypernova_tween(request):
         request.hypernova_batch = batch_request_factory(
-            get_batch_url(),
-            plugin_controller,
-            json_encoder,
+            batch_url=get_batch_url(),
+            plugin_controller=plugin_controller,
+            json_encoder=json_encoder,
         )
         response = handler(request)
 

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-import json
+from json import JSONEncoder
 
 from pyramid_hypernova.batch import BatchRequest
 from pyramid_hypernova.plugins import PluginController
@@ -20,7 +20,7 @@ def hypernova_tween_factory(handler, registry):
         BatchRequest,
     )
 
-    json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', json.JSONEncoder)
+    json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', JSONEncoder())
 
     def hypernova_tween(request):
         request.hypernova_batch = batch_request_factory(

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import json
+
 from pyramid_hypernova.batch import BatchRequest
 from pyramid_hypernova.plugins import PluginController
 from pyramid_hypernova.rendering import RenderToken
@@ -18,7 +20,7 @@ def hypernova_tween_factory(handler, registry):
         BatchRequest,
     )
 
-    json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', None)
+    json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', json.JSONEncoder)
 
     def hypernova_tween(request):
         request.hypernova_batch = batch_request_factory(

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -18,8 +18,14 @@ def hypernova_tween_factory(handler, registry):
         BatchRequest,
     )
 
+    json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', None)
+
     def hypernova_tween(request):
-        request.hypernova_batch = batch_request_factory(get_batch_url(), plugin_controller)
+        request.hypernova_batch = batch_request_factory(
+            get_batch_url(),
+            plugin_controller,
+            json_encoder,
+        )
         response = handler(request)
 
         hypernova_response = request.hypernova_batch.submit()

--- a/testing/json_encoder.py
+++ b/testing/json_encoder.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import json
+
+
+class ComplexJSONEncoder(json.JSONEncoder):
+    """ A custom JSONEncoder that, in addition to everything that the generic JSONEncoder already
+    supports, also encodes complex numbers. Copied from https://docs.python.org/2/library/json.html
+    """
+
+    def default(self, obj):
+        if isinstance(obj, complex):
+            return [obj.real, obj.imag]
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, obj)

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -136,7 +136,12 @@ def test_data(request):
 @pytest.fixture(params=[None, 1, 2])
 def batch_request(spy_plugin_controller, test_data, request):
     json_encoder = ComplexJSONEncoder() if test_data[1] else JSONEncoder()
-    return BatchRequest('http://localhost:8888', spy_plugin_controller, json_encoder, max_batch_size=request.param)
+    return BatchRequest(
+        'http://localhost:8888',
+        spy_plugin_controller,
+        max_batch_size=request.param,
+        json_encoder=json_encoder,
+    )
 
 
 class TestBatchRequest(object):

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -44,9 +44,9 @@ def test_tween_replaces_tokens():
     response = tween(mock_request)
 
     mock_batch_request_factory.assert_called_once_with(
-        'http://localhost:8888/batch',
-        mock.ANY,
-        mock_json_encoder,
+        batch_url='http://localhost:8888/batch',
+        plugin_controller=mock.ANY,
+        json_encoder=mock_json_encoder,
     )
     assert mock_batch_request_factory.return_value.submit.called
     assert response.text == '<div>REACT!</div>'

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -20,10 +20,13 @@ def test_tween_replaces_tokens():
     mock_batch_request_factory = mock.Mock()
     mock_get_batch_url = mock.Mock(return_value='http://localhost:8888/batch')
 
+    mock_json_encoder = mock.Mock()
+
     mock_registry = mock.Mock()
     mock_registry.settings = {
         'pyramid_hypernova.get_batch_url': mock_get_batch_url,
         'pyramid_hypernova.batch_request_factory': mock_batch_request_factory,
+        'pyramid_hypernova.json_encoder': mock_json_encoder,
     }
 
     tween = hypernova_tween_factory(mock_handler, mock_registry)
@@ -43,6 +46,7 @@ def test_tween_replaces_tokens():
     mock_batch_request_factory.assert_called_once_with(
         'http://localhost:8888/batch',
         mock.ANY,
+        mock_json_encoder,
     )
     assert mock_batch_request_factory.return_value.submit.called
     assert response.text == '<div>REACT!</div>'


### PR DESCRIPTION
This is to support the usage of custom `JSONEncoder` classes to encode the JSON payload that gets sent to hypernova. Currently, `pyramid-hypernova` expects the data payload to be serializable by the default `JSONEncoder`, which might not be the case for every user. 

In our case, we have special objects in our data such as translation strings that we treat as primitives, and we have previously built a custom JSON encoder to handle them for existing JSON pyramid endpoints. Right now, to make our data serializable by the generic encoder that `pyramid-hypernova` uses, we are doing a back-and-forth conversion by encoding the original data with our custom JSON encoder, and then decoding with a generic decoder :/

A more proper solution for us, of course, would be to implement something to normalize the data without wasting time encoding and decoding it to and from JSON, but I also thought we can easily make `pyramid-hypernova` support the usage of custom JSON encoders.