### PR TITLE
Query Hypernova synchronously for pages with only one batch to render

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -8,7 +8,6 @@ import uuid
 from json import JSONEncoder
 
 from more_itertools import chunked
-import os
 
 from pyramid_hypernova.rendering import render_blank_markup
 from pyramid_hypernova.rendering import RenderToken

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 import fido
-from fido.exceptions import NetworkError
 import requests
+from fido.exceptions import NetworkError
 from requests.exceptions import HTTPError
+
 
 def create_jobs_payload(jobs):
     return {
@@ -13,16 +14,19 @@ def create_jobs_payload(jobs):
         for identifier, job in jobs.items()
     }
 
+
 class HypernovaQueryError(Exception):
     def __init__(self, child_error):
         super(HypernovaQueryError, self).__init__(str(child_error))
 
+
 class HypernovaQuery(object):
     """ Abstract Hypernova query """
+
     def __init__(self, job_group, url, json_encoder, synchronous):
         """
         Build a Hypernova query.
-        :param job_group: A job group (see create_job_groups in batch.py)
+        :param job_group: A job group (see create_job_groups)
         :param url: the URL of the Hypernova server we should query
         :param json_encoder: A JSON encoder to encode the query with
         :param synchronous: True to synchronously query CRS (faster), False to

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import fido
+from fido.exceptions import NetworkError
+import requests
+from requests.exceptions import HTTPError
+
+def create_jobs_payload(jobs):
+    return {
+        identifier: {'name': job.name, 'data': job.data}
+        for identifier, job in jobs.items()
+    }
+
+class HypernovaQueryError(Exception):
+    def __init__(self, child_error):
+        super(HypernovaQueryError, self).__init__(str(child_error))
+
+class HypernovaQuery(object):
+    """ Abstract Hypernova query """
+    def __init__(self, job_group, url, json_encoder, synchronous):
+        """
+        Build a Hypernova query.
+        :param job_group: A job group (see create_job_groups in batch.py)
+        :param url: the URL of the Hypernova server we should query
+        :param json_encoder: A JSON encoder to encode the query with
+        :param synchronous: True to synchronously query CRS (faster), False to
+            query asynchronously (allows parallelization)
+        """
+        self.job_group = job_group
+        self.url = url
+        self.json_encoder = json_encoder
+        self.synchronous = synchronous
+
+    def send(self):
+        """ Query Hypernova """
+        job_str = self.json_encoder.encode(create_jobs_payload(self.job_group))
+        job_bytes = job_str.encode('utf-8')
+
+        if self.synchronous:
+            self.response = requests.post(
+                url=self.url,
+                headers={
+                    'Content-Type': 'application/json',
+                },
+                data=job_bytes,
+            )
+        else:
+            self.response = fido.fetch(
+                url=self.url,
+                headers={
+                    'Content-Type': ['application/json'],
+                },
+                method='POST',
+                body=job_bytes,
+            )
+
+    def json(self):
+        """
+        Get the JSON response from Hypernova.
+        :rtype: Dict
+        """
+        if self.synchronous:
+            try:
+                self.response.raise_for_status()
+                json = self.response.json()
+            except HTTPError as e:
+                raise HypernovaQueryError(e)
+        else:
+            try:
+                result = self.response.wait()
+                json = result.json()
+            except NetworkError as e:
+                raise HypernovaQueryError(e)
+        return json

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     install_requires=[
         'fido',
         'more-itertools',
+        'requests',
     ],
     packages=find_packages(exclude=('tests*', 'testing*')),
 )

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -6,14 +6,13 @@ from json import JSONEncoder
 
 import mock
 import pytest
-from fido.exceptions import NetworkError
 
 from pyramid_hypernova.batch import BatchRequest
 from pyramid_hypernova.batch import create_fallback_response
 from pyramid_hypernova.batch import create_job_groups
-from pyramid_hypernova.batch import create_jobs_payload
 from pyramid_hypernova.plugins import PluginController
 from pyramid_hypernova.rendering import render_blank_markup
+from pyramid_hypernova.request import HypernovaQueryError
 from pyramid_hypernova.types import HypernovaError
 from pyramid_hypernova.types import Job
 from pyramid_hypernova.types import JobResult
@@ -61,36 +60,6 @@ def test_create_fallback_response(jobs, throw_client_error, json_encoder):
     }
 
     assert create_fallback_response(jobs, throw_client_error, json_encoder) == expected_response
-
-
-def test_create_jobs_payload():
-    jobs = {
-        'some-unique-id': Job(
-            name='FooBar.js',
-            data={'baz': 1234},
-        ),
-        'some-other-unique-id': Job(
-            name='MyComponent.js',
-            data={'title': 'sup'},
-        ),
-    }
-
-    expected_result = {
-        'some-unique-id': {
-            'name': 'FooBar.js',
-            'data': {
-                'baz': 1234,
-            },
-        },
-        'some-other-unique-id': {
-            'name': 'MyComponent.js',
-            'data': {
-                'title': 'sup',
-            },
-        },
-    }
-
-    assert create_jobs_payload(jobs) == expected_result
 
 
 @pytest.mark.parametrize('max_batch_size,expected', [
@@ -144,9 +113,15 @@ def batch_request(spy_plugin_controller, test_data, request):
     )
 
 
+@pytest.fixture
+def mock_hypernova_query():
+    with mock.patch('pyramid_hypernova.batch.HypernovaQuery') as mock_hypernova_query:
+        yield mock_hypernova_query
+
+
 class TestBatchRequest(object):
 
-    def test_successful_batch_request(self, spy_plugin_controller, test_data, batch_request):
+    def test_successful_batch_request(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         token_1 = batch_request.render('component-1.js', data[0])
         token_2 = batch_request.render('component-2.js', data[1])
@@ -184,17 +159,18 @@ class TestBatchRequest(object):
             }
         }
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.return_value = fake_response_json
-            response = batch_request.submit()
+        mock_hypernova_query.return_value.json.return_value = fake_response_json
+        response = batch_request.submit()
 
         if batch_request.max_batch_size is None:
-            assert mock_fetch.call_count == 1
+            assert mock_hypernova_query.call_count == 1
         else:
             # Division (rounded-up) up to get total number of calls
             jobs_count = len(batch_request.jobs)
             max_batch_size = batch_request.max_batch_size
-            assert mock_fetch.call_count == (jobs_count + (max_batch_size - 1)) // max_batch_size
+            batch_count = (jobs_count + (max_batch_size - 1)) // max_batch_size
+            assert mock_hypernova_query.call_count == batch_count
+            mock_hypernova_query.assert_called_with(mock.ANY, mock.ANY, mock.ANY, batch_count == 1)
 
         assert response == {
             token_1.identifier: JobResult(
@@ -214,14 +190,19 @@ class TestBatchRequest(object):
             ),
         }
 
-    def test_batch_request_with_no_jobs_doesnt_post(self, spy_plugin_controller, batch_request):
-        with mock.patch('fido.fetch') as mock_fetch:
-            response = batch_request.submit()
+    def test_batch_request_with_no_jobs_doesnt_post(self, spy_plugin_controller, batch_request, mock_hypernova_query):
+        response = batch_request.submit()
 
-        assert not mock_fetch.called
+        assert not mock_hypernova_query.called
         assert response == {}
 
-    def test_batch_request_with_component_errors(self, spy_plugin_controller, test_data, batch_request):
+    def test_batch_request_with_component_errors(
+        self,
+        spy_plugin_controller,
+        test_data,
+        batch_request,
+        mock_hypernova_query,
+    ):
         data = test_data[0]
         token_1 = batch_request.render('MyComponent1.js', data[0])
         token_2 = batch_request.render('MyComponent2.js', data[1])
@@ -245,17 +226,18 @@ class TestBatchRequest(object):
             }
         }
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.return_value = fake_response_json
-            response = batch_request.submit()
+        mock_hypernova_query.return_value.json.return_value = fake_response_json
+        response = batch_request.submit()
 
         if batch_request.max_batch_size is None:
-            assert mock_fetch.call_count == 1
+            assert mock_hypernova_query.call_count == 1
         else:
             # Division (rounded-up) up to get total number of calls
             jobs_count = len(batch_request.jobs)
             max_batch_size = batch_request.max_batch_size
-            assert mock_fetch.call_count == (jobs_count + (max_batch_size - 1)) // max_batch_size
+            batch_count = (jobs_count + (max_batch_size - 1)) // max_batch_size
+            assert mock_hypernova_query.call_count == batch_count
+            mock_hypernova_query.assert_called_with(mock.ANY, mock.ANY, mock.ANY, batch_count == 1)
 
         assert response == {
             token_1.identifier: JobResult(
@@ -274,7 +256,13 @@ class TestBatchRequest(object):
             )
         }
 
-    def test_batch_request_with_application_error(self, spy_plugin_controller, test_data, batch_request):
+    def test_batch_request_with_application_error(
+        self,
+        spy_plugin_controller,
+        test_data,
+        batch_request,
+        mock_hypernova_query,
+    ):
         data = test_data[0]
         job = Job(name='MyComponent.js', data=data[0])
         token = batch_request.render('MyComponent.js', data[0])
@@ -287,17 +275,18 @@ class TestBatchRequest(object):
             }
         }
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.return_value = fake_response_json
-            response = batch_request.submit()
+        mock_hypernova_query.return_value.json.return_value = fake_response_json
+        response = batch_request.submit()
 
         if batch_request.max_batch_size is None:
-            assert mock_fetch.call_count == 1
+            assert mock_hypernova_query.call_count == 1
         else:
             # Division (rounded-up) up to get total number of calls
             jobs_count = len(batch_request.jobs)
             max_batch_size = batch_request.max_batch_size
-            assert mock_fetch.call_count == (jobs_count + (max_batch_size - 1)) // max_batch_size
+            batch_count = (jobs_count + (max_batch_size - 1)) // max_batch_size
+            assert mock_hypernova_query.call_count == batch_count
+            mock_hypernova_query.assert_called_with(mock.ANY, mock.ANY, mock.ANY, batch_count == 1)
 
         assert response == {
             token.identifier: JobResult(
@@ -311,27 +300,34 @@ class TestBatchRequest(object):
             ),
         }
 
-    def test_batch_request_with_unhealthy_service(self, spy_plugin_controller, test_data, batch_request):
+    def test_batch_request_with_unhealthy_service(
+        self,
+        spy_plugin_controller,
+        test_data,
+        batch_request,
+        mock_hypernova_query,
+    ):
         data = test_data[0]
         job = Job(name='MyComponent.js', data=data[0])
         token = batch_request.render('MyComponent.js', data[0])
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.side_effect = NetworkError('oh no')
-            response = batch_request.submit()
+        mock_hypernova_query.return_value.json.side_effect = HypernovaQueryError('oh no')
+        response = batch_request.submit()
 
         if batch_request.max_batch_size is None:
-            assert mock_fetch.call_count == 1
+            assert mock_hypernova_query.call_count == 1
         else:
             # Division (rounded-up) up to get total number of calls
             jobs_count = len(batch_request.jobs)
             max_batch_size = batch_request.max_batch_size
-            assert mock_fetch.call_count == (jobs_count + (max_batch_size - 1)) // max_batch_size
+            batch_count = (jobs_count + (max_batch_size - 1)) // max_batch_size
+            assert mock_hypernova_query.call_count == batch_count
+            mock_hypernova_query.assert_called_with(mock.ANY, mock.ANY, mock.ANY, batch_count == 1)
 
         assert response == {
             token.identifier: JobResult(
                 error=HypernovaError(
-                    name="<class 'fido.exceptions.NetworkError'>",
+                    name="<class 'pyramid_hypernova.request.HypernovaQueryError'>",
                     message='oh no',
                     stack=mock.ANY,
                 ),
@@ -362,14 +358,13 @@ class TestBatchRequestLifecycleMethods(object):
             data[0],
         )
 
-    def test_calls_prepare_request(self, spy_plugin_controller, test_data, batch_request):
+    def test_calls_prepare_request(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         batch_request.render('MySsrComponent.js', data[0])
 
         original_jobs = dict(batch_request.jobs)
 
-        with mock.patch('fido.fetch'):
-            batch_request.submit()
+        batch_request.submit()
 
         spy_plugin_controller.prepare_request.assert_has_calls([
             mock.call(original_jobs),
@@ -379,18 +374,17 @@ class TestBatchRequestLifecycleMethods(object):
             original_jobs
         )
 
-    def test_calls_will_send_request(self, spy_plugin_controller, test_data, batch_request):
+    def test_calls_will_send_request(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         batch_request.render('MySsrComponent.js', data[0])
 
-        with mock.patch('fido.fetch'):
-            batch_request.submit()
+        batch_request.submit()
 
         spy_plugin_controller.will_send_request.assert_has_calls([
             mock.call(batch_request.jobs),
         ])
 
-    def test_calls_after_response(self, spy_plugin_controller, test_data, batch_request):
+    def test_calls_after_response(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         ssr_token = batch_request.render('MySsrComponent.js', data[0])
 
@@ -404,9 +398,8 @@ class TestBatchRequestLifecycleMethods(object):
             }
         }
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.return_value = fake_response_json
-            response = batch_request.submit()
+        mock_hypernova_query.return_value.json.return_value = fake_response_json
+        response = batch_request.submit()
 
         assert spy_plugin_controller.after_response.called
 
@@ -420,7 +413,7 @@ class TestBatchRequestLifecycleMethods(object):
 
         assert response == spy_plugin_controller.after_response(parsed_response)
 
-    def test_calls_on_success(self, spy_plugin_controller, test_data, batch_request):
+    def test_calls_on_success(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         ssr_token = batch_request.render('MySsrComponent.js', data[0])
 
@@ -434,16 +427,15 @@ class TestBatchRequestLifecycleMethods(object):
             }
         }
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.return_value = fake_response_json
-            response = batch_request.submit()
+        mock_hypernova_query.return_value.json.return_value = fake_response_json
+        response = batch_request.submit()
 
         spy_plugin_controller.on_success.assert_called_once_with(
             response,
             batch_request.jobs,
         )
 
-    def test_calls_on_error(self, spy_plugin_controller, test_data, batch_request):
+    def test_calls_on_error(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         batch_request.render('MyComponent.js', data[0])
 
@@ -455,9 +447,8 @@ class TestBatchRequestLifecycleMethods(object):
             }
         }
 
-        with mock.patch('fido.fetch') as mock_fetch:
-            mock_fetch.return_value.wait.return_value.json.return_value = fake_response_json
-            batch_request.submit()
+        mock_hypernova_query.return_value.json.return_value = fake_response_json
+        batch_request.submit()
 
         spy_plugin_controller.on_error.assert_called_once_with(
             HypernovaError(
@@ -468,21 +459,23 @@ class TestBatchRequestLifecycleMethods(object):
             batch_request.jobs,
         )
 
-    def test_calls_on_error_on_unhealthy_service(self, spy_plugin_controller, test_data, batch_request):
+    def test_calls_on_error_on_unhealthy_service(
+        self,
+        spy_plugin_controller,
+        test_data,
+        batch_request,
+        mock_hypernova_query,
+    ):
         data = test_data[0]
         batch_request.render('MyComponent.js', data[0])
 
-        with mock.patch(
-            'fido.fetch'
-        ) as mock_fetch, mock.patch(
-            'traceback.format_tb'
-        ) as mock_format_tb:
-            mock_fetch.return_value.wait.return_value.json.side_effect = NetworkError('oh no')
+        with mock.patch('traceback.format_tb') as mock_format_tb:
+            mock_hypernova_query.return_value.json.side_effect = HypernovaQueryError('oh no')
             batch_request.submit()
 
         spy_plugin_controller.on_error.assert_called_once_with(
             HypernovaError(
-                name="<class 'fido.exceptions.NetworkError'>",
+                name="<class 'pyramid_hypernova.request.HypernovaQueryError'>",
                 message='oh no',
                 stack=mock_format_tb.return_value,
             ),

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from json import JSONEncoder
+
+import mock
+import pytest
+from fido.exceptions import NetworkError
+from requests.exceptions import HTTPError
+
+from pyramid_hypernova.request import create_jobs_payload
+from pyramid_hypernova.request import HypernovaQuery
+from pyramid_hypernova.request import HypernovaQueryError
+from pyramid_hypernova.types import Job
+
+TEST_JOB_GROUP = {
+    'yellow keycard': Job('open the exit door', 'behind the cacodemon'),
+    'red skull key': Job('get the bfg9k', 'rocket jump from the platform'),
+}
+
+
+@pytest.fixture
+def mock_fido_fetch():
+    with mock.patch('pyramid_hypernova.request.fido.fetch') as mock_fido_fetch:
+        yield mock_fido_fetch
+
+
+@pytest.fixture
+def mock_requests_post():
+    with mock.patch('pyramid_hypernova.request.requests.post') as mock_requests_post:
+        yield mock_requests_post
+
+
+def test_create_jobs_payload():
+    result = create_jobs_payload(TEST_JOB_GROUP)
+
+    assert result == {
+        'yellow keycard': {
+            'name': 'open the exit door',
+            'data': 'behind the cacodemon',
+        },
+        'red skull key': {
+            'name': 'get the bfg9k',
+            'data': 'rocket jump from the platform',
+        }
+    }
+
+
+class TestHypernovaQuery(object):
+
+    def test_successful_send_synchronous(self, mock_fido_fetch, mock_requests_post):
+        mock_requests_post.return_value.json.return_value = 'ayy lmao'
+
+        query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), True)
+        query.send()
+
+        mock_fido_fetch.assert_not_called()
+        mock_requests_post.assert_called_once()
+
+        assert query.json() == 'ayy lmao'
+
+    def test_erroneous_send_synchronous(self, mock_fido_fetch, mock_requests_post):
+        mock_requests_post.return_value.raise_for_status.side_effect = HTTPError('ayy lmao')
+
+        query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), True)
+        query.send()
+
+        mock_fido_fetch.assert_not_called()
+        mock_requests_post.assert_called_once()
+
+        try:
+            query.json()
+        except HypernovaQueryError as e:
+            exception = e
+
+        assert str(exception) == str(HypernovaQueryError(HTTPError('ayy lmao')))
+
+    def test_successful_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
+        mock_fido_fetch.return_value.wait.return_value.json.return_value = 'ayy lmao'
+
+        query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), False)
+        query.send()
+
+        mock_fido_fetch.assert_called_once()
+        mock_requests_post.assert_not_called()
+
+        assert query.json() == 'ayy lmao'
+
+    def test_erroneous_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
+        mock_fido_fetch.return_value.wait.side_effect = NetworkError('ayy lmao')
+
+        query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), False)
+        query.send()
+
+        mock_fido_fetch.assert_called_once()
+        mock_requests_post.assert_not_called()
+
+        try:
+            query.json()
+        except HypernovaQueryError as e:
+            exception = e
+
+        assert str(exception) == str(HypernovaQueryError(NetworkError('ayy lmao')))


### PR DESCRIPTION
Asynchronous code inherently has some overhead compared to synchronous code. Python2.7 in particular is bad about it thanks to the GIL and how it's managed. Since most pages only have one React root to server-side render, pyramid-hypernova currently just makes an asynchronous request and immediately waits for it to complete, performing no useful work while the request takes place and incurring the asynchronous code penalty for no benefit. This CR makes BatchRequest query Hypernova synchronously when there's only one batch to submit. In my (admittedly limited) testing, this CR shaves an average of 25ms off the time required to query Hypernova in the single-batch case.

Tests to come if the overall approach gets a signoff.