### PR TITLE
Format Python tracebacks more like JS tracebacks

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -131,9 +131,9 @@ class BatchRequest(object):
             __, __, exc_traceback = sys.exc_info()
 
             error = HypernovaError(
-                repr(type(e)),
+                type(e).__name__,
                 str(e),
-                traceback.format_tb(exc_traceback),
+                [line.rstrip('\n') for line in traceback.format_tb(exc_traceback)],
             )
             self.plugin_controller.on_error(error, jobs)
             response = create_fallback_response(jobs, True, self.json_encoder, error)

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -331,7 +331,7 @@ class TestBatchRequest(object):
         assert response == {
             token.identifier: JobResult(
                 error=HypernovaError(
-                    name="<class 'fido.exceptions.NetworkError'>",
+                    name='NetworkError',
                     message='oh no',
                     stack=mock.ANY,
                 ),
@@ -475,16 +475,20 @@ class TestBatchRequestLifecycleMethods(object):
         with mock.patch(
             'fido.fetch'
         ) as mock_fetch, mock.patch(
-            'traceback.format_tb'
-        ) as mock_format_tb:
+            'traceback.format_tb',
+            return_value=[
+                'Traceback:\n',
+                '  foo:\n',
+            ],
+        ):
             mock_fetch.return_value.wait.return_value.json.side_effect = NetworkError('oh no')
             batch_request.submit()
 
         spy_plugin_controller.on_error.assert_called_once_with(
             HypernovaError(
-                name="<class 'fido.exceptions.NetworkError'>",
+                name='NetworkError',
                 message='oh no',
-                stack=mock_format_tb.return_value,
+                stack=['Traceback:', '  foo:'],
             ),
             batch_request.jobs,
         )


### PR DESCRIPTION
Fixes #14.

Now tracebacks from both Python and JS don't contain trailing newlines in their `stack` list. This makes it a little easier to pretty-print them (don't need to either strip or add newlines depending on where the error came from).

I also changed from the repr string of the error type to its name, since Python tracebacks are generally formatted as `ValueError: foo` as the last line of the traceback and not `<type 'exceptions.ValueError'>: foo`.