### PR TITLE
Provide better error messages for non-2xx responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.coverage
 /.pytest_cache
 /.tox
+/build
 /coverage-html
 /dist
 /venv

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -81,7 +81,8 @@ class HypernovaQuery(object):
                 # problem (socket closed, etc.) and not for non-2xx statuses.
                 if result.code != 200:
                     raise HypernovaQueryError(
-                        'Received response with status code {} from Hypernova.'.format(result.code),
+                        'Received response with status code {} from Hypernova. Response body:\n'
+                        '{}'.format(result.code, result.body.decode('UTF-8', 'ignore')),
                     )
                 else:
                     json = result.json()

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -74,7 +74,15 @@ class HypernovaQuery(object):
         else:
             try:
                 result = self.response.wait()
-                json = result.json()
             except NetworkError as e:
                 raise HypernovaQueryError(e)
+            else:
+                # NetworkError is only called raised there's an actual network
+                # problem (socket closed, etc.) and not for non-2xx statuses.
+                if result.code != 200:
+                    raise HypernovaQueryError(
+                        'Received response with status code {} from Hypernova.'.format(result.code),
+                    )
+                else:
+                    json = result.json()
         return json

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -69,14 +69,12 @@ class TestHypernovaQuery(object):
         mock_fido_fetch.assert_not_called()
         mock_requests_post.assert_called_once()
 
-        try:
+        with pytest.raises(HypernovaQueryError) as exc_info:
             query.json()
-        except HypernovaQueryError as e:
-            exception = e
-
-        assert str(exception) == str(HypernovaQueryError(HTTPError('ayy lmao')))
+        assert str(exc_info.value) == str(HypernovaQueryError(NetworkError('ayy lmao')))
 
     def test_successful_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
+        mock_fido_fetch.return_value.wait.return_value.code = 200
         mock_fido_fetch.return_value.wait.return_value.json.return_value = 'ayy lmao'
 
         query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), False)
@@ -96,9 +94,20 @@ class TestHypernovaQuery(object):
         mock_fido_fetch.assert_called_once()
         mock_requests_post.assert_not_called()
 
-        try:
+        with pytest.raises(HypernovaQueryError) as exc_info:
             query.json()
-        except HypernovaQueryError as e:
-            exception = e
+        assert str(exc_info.value) == str(HypernovaQueryError(NetworkError('ayy lmao')))
 
-        assert str(exception) == str(HypernovaQueryError(NetworkError('ayy lmao')))
+    def test_error_status_code_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
+        mock_fido_fetch.return_value.wait.return_value.code = 504
+        mock_fido_fetch.return_value.wait.return_value.json.side_effect = AssertionError()
+
+        query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), False)
+        query.send()
+
+        mock_fido_fetch.assert_called_once()
+        mock_requests_post.assert_not_called()
+
+        with pytest.raises(HypernovaQueryError) as exc_info:
+            query.json()
+        assert str(exc_info.value) == 'Received response with status code 504 from Hypernova.'

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -100,6 +100,7 @@ class TestHypernovaQuery(object):
 
     def test_error_status_code_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
         mock_fido_fetch.return_value.wait.return_value.code = 504
+        mock_fido_fetch.return_value.wait.return_value.body = b'<h1>504 Bad Gateway</h1>'
         mock_fido_fetch.return_value.wait.return_value.json.side_effect = AssertionError()
 
         query = HypernovaQuery(TEST_JOB_GROUP, 'google.com', JSONEncoder(), False)
@@ -110,4 +111,7 @@ class TestHypernovaQuery(object):
 
         with pytest.raises(HypernovaQueryError) as exc_info:
             query.json()
-        assert str(exc_info.value) == 'Received response with status code 504 from Hypernova.'
+        assert str(exc_info.value) == (
+            'Received response with status code 504 from Hypernova. Response body:\n'
+            '<h1>504 Bad Gateway</h1>'
+        )


### PR DESCRIPTION
We're currently trying to parse the response body as JSON for non-2xx responses which produces a confusing error message. We should ignore it entirely and raise a more helpful error instead.

Before:

```
Date: 2019-01-30 16:39:05.636316
Stream: None
Level: ERROR
Uncaught Exception: False
Server: dev45-uswest1adevc
[...]

Traceback from pyramid_hypernova:
  File "/nail/home/ckuehl/proj/pyramid-hypernova/pyramid_hypernova/batch.py", line 108, in process_responses
    response_json = query.json()
  File "/nail/home/ckuehl/proj/pyramid-hypernova/pyramid_hypernova/request.py", line 87, in json
    json = result.json()
  File "/nail/home/ckuehl/pg/yelp-main/virtualenv_run/lib/python2.7/site-packages/fido/fido.py", line 98, in json
    return json.loads(self.body.decode('utf-8'))
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

After:

```
Date: 2019-01-30 16:37:18.101181
Stream: None
Level: ERROR
Uncaught Exception: False
Server: dev45-uswest1adevc
[...]

Traceback from pyramid_hypernova:
  File "/nail/home/ckuehl/proj/pyramid-hypernova/pyramid_hypernova/batch.py", line 108, in process_responses
    response_json = query.json()
  File "/nail/home/ckuehl/proj/pyramid-hypernova/pyramid_hypernova/request.py", line 84, in json
    'Received response with status code {} from Hypernova.'.format(result.code),
HypernovaQueryError: Received response with status code 502 from Hypernova.
```

This only affects the asynchronous (fido) flow; requests is already raising a reasonable error when calling `raise_for_status()`.