### PR TITLE
Add token replacement support for JSON responses

### DIFF
--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -8,6 +8,7 @@ import json
 from pyramid_hypernova.batch import BatchRequest
 from pyramid_hypernova.plugins import PluginController
 from pyramid_hypernova.rendering import RenderToken
+from six import string_types
 
 
 def hypernova_tween_factory(handler, registry):
@@ -46,7 +47,7 @@ def hypernova_tween_factory(handler, registry):
                 key, value, parent_dict = stack.pop()
                 if isinstance(value, dict):
                     stack.extend([(new_key, new_value, value) for new_key, new_value in value.items()])
-                elif isinstance(value, unicode):
+                elif isinstance(value, string_types):
                     for identifier, job_result in hypernova_response.items():
                         token = RenderToken(identifier)
                         value = value.replace(str(token), job_result.html)

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -2,13 +2,14 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
-from json import JSONEncoder
 import json
+from json import JSONEncoder
+
+from six import string_types
 
 from pyramid_hypernova.batch import BatchRequest
 from pyramid_hypernova.plugins import PluginController
 from pyramid_hypernova.rendering import RenderToken
-from six import string_types
 
 
 def hypernova_tween_factory(handler, registry):
@@ -34,7 +35,7 @@ def hypernova_tween_factory(handler, registry):
 
         hypernova_response = request.hypernova_batch.submit()
 
-        if request.response.content_type == 'application/json':
+        if response.content_type == 'application/json':
             # For a JSON-encoded response, load the JSON into a dict and iteratively
             # perform token replacement. At the end, we re-encode the modified dict
             # back into the reponse.
@@ -57,9 +58,9 @@ def hypernova_tween_factory(handler, registry):
             try:
                 # In python 2, decode str to unicode before writing to response.text
                 response_text = response_text.decode('utf-8')
-            except:
+            except AttributeError:  # pragma: no cover - This line isn't hit in python 2
                 # If '.decode' failed, we're in python 3 and response_text is already in unicode
-                pass
+                pass  # pragma: no cover - This line isn't hit in python 2
             response.text = response_text
             return response
 

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 from json import JSONEncoder
+import json
 
 from pyramid_hypernova.batch import BatchRequest
 from pyramid_hypernova.plugins import PluginController
@@ -31,6 +32,23 @@ def hypernova_tween_factory(handler, registry):
         response = handler(request)
 
         hypernova_response = request.hypernova_batch.submit()
+
+        if request.response.content_type == 'application/json':
+            response_dict = json.loads(response.text)
+            stack = [(key, value, response_dict) for key, value in response_dict.items()]
+
+            while stack:
+                key, value, parent_dict = stack.pop()
+                if isinstance(value, dict):
+                    stack.extend([(new_key, new_value, value) for new_key, new_value in value.items()])
+                elif isinstance(value, unicode):
+                    for identifier, job_result in hypernova_response.items():
+                        token = RenderToken(identifier)
+                        value = value.replace(str(token), job_result.html)
+                    parent_dict[key] = value
+
+            response.text = json.dumps(response_dict).decode('utf-8')
+            return response
 
         for identifier, job_result in hypernova_response.items():
             token = RenderToken(identifier)

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'fido',
         'more-itertools',
         'requests',
+        'six',
     ],
     packages=find_packages(exclude=('tests*', 'testing*')),
 )

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -2,51 +2,121 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import json
+
 import mock
+import pytest
 
 from pyramid_hypernova.rendering import RenderToken
 from pyramid_hypernova.tweens import hypernova_tween_factory
 from pyramid_hypernova.types import JobResult
 
 
-def test_tween_replaces_tokens():
-    token = RenderToken('my-unique-id')
+class TestTweens(object):
 
-    mock_handler = mock.Mock()
-    mock_handler.return_value = mock.Mock(
-        text=str(token)
-    )
+    @pytest.fixture(autouse=True)
+    def mock_setup(self):
+        self.token = RenderToken('my-unique-id')
+        self.mock_batch_request_factory = mock.Mock()
+        self.mock_json_encoder = mock.Mock()
 
-    mock_batch_request_factory = mock.Mock()
-    mock_get_batch_url = mock.Mock(return_value='http://localhost:8888/batch')
+        mock_get_batch_url = mock.Mock(return_value='http://localhost:8888/batch')
+        self.mock_registry = mock.Mock()
+        self.mock_registry.settings = {
+            'pyramid_hypernova.get_batch_url': mock_get_batch_url,
+            'pyramid_hypernova.batch_request_factory': self.mock_batch_request_factory,
+            'pyramid_hypernova.json_encoder': self.mock_json_encoder,
+        }
 
-    mock_json_encoder = mock.Mock()
+        self.mock_batch_request_factory.return_value.submit.return_value = {
+            'my-unique-id': JobResult(
+                error=None,
+                html='<div>REACT!</div>',
+                job=None,
+            )
+        }
 
-    mock_registry = mock.Mock()
-    mock_registry.settings = {
-        'pyramid_hypernova.get_batch_url': mock_get_batch_url,
-        'pyramid_hypernova.batch_request_factory': mock_batch_request_factory,
-        'pyramid_hypernova.json_encoder': mock_json_encoder,
-    }
+        self.mock_request = mock.Mock()
+        self.mock_handler = mock.Mock()
 
-    tween = hypernova_tween_factory(mock_handler, mock_registry)
-
-    mock_request = mock.Mock()
-
-    mock_batch_request_factory.return_value.submit.return_value = {
-        'my-unique-id': JobResult(
-            error=None,
-            html='<div>REACT!</div>',
-            job=None,
+    def test_tween_replaces_tokens(self):
+        self.mock_handler.return_value = mock.Mock(
+            text=str(self.token)
         )
-    }
+        tween = hypernova_tween_factory(self.mock_handler, self.mock_registry)
+        mock_request = mock.Mock()
 
-    response = tween(mock_request)
+        response = tween(mock_request)
 
-    mock_batch_request_factory.assert_called_once_with(
-        batch_url='http://localhost:8888/batch',
-        plugin_controller=mock.ANY,
-        json_encoder=mock_json_encoder,
-    )
-    assert mock_batch_request_factory.return_value.submit.called
-    assert response.text == '<div>REACT!</div>'
+        self.mock_batch_request_factory.assert_called_once_with(
+            batch_url='http://localhost:8888/batch',
+            plugin_controller=mock.ANY,
+            json_encoder=self.mock_json_encoder,
+        )
+        assert self.mock_batch_request_factory.return_value.submit.called
+        assert response.text == '<div>REACT!</div>'
+
+    # TODO: Add a test with response text that escapes markup tags
+    def test_tween_replaces_tokens_in_json(self):
+        text = json.dumps({
+            'js_display': {},
+            'body': str(self.token),
+            'number': 3,
+        })
+
+        self.mock_handler.return_value = mock.Mock(
+            text=text,
+            content_type='application/json',
+        )
+
+        tween = hypernova_tween_factory(self.mock_handler, self.mock_registry)
+        mock_request = mock.Mock()
+
+        response = tween(mock_request)
+
+        self.mock_batch_request_factory.assert_called_once_with(
+            batch_url='http://localhost:8888/batch',
+            plugin_controller=mock.ANY,
+            json_encoder=self.mock_json_encoder,
+        )
+        assert self.mock_batch_request_factory.return_value.submit.called
+        assert json.loads(response.text) == {
+            'js_display': {},
+            'body': '<div>REACT!</div>',
+            'number': 3,
+        }
+
+    def test_tween_replaces_tokens_in_json_nested(self):
+        text = json.dumps({
+            'js_display': {},
+            'content': {
+                'body': str(self.token),
+                'is_cool': True,
+            },
+            'number': 3,
+        })
+
+        self.mock_handler.return_value = mock.Mock(
+            text=text,
+            content_type='application/json',
+        )
+
+        tween = hypernova_tween_factory(self.mock_handler, self.mock_registry)
+        mock_request = mock.Mock()
+
+        response = tween(mock_request)
+
+        self.mock_batch_request_factory.assert_called_once_with(
+            batch_url='http://localhost:8888/batch',
+            plugin_controller=mock.ANY,
+            json_encoder=self.mock_json_encoder,
+        )
+        assert self.mock_batch_request_factory.return_value.submit.called
+        assert json.loads(response.text) == {
+            'js_display': {},
+            'content': {
+                'body': '<div>REACT!</div>',
+                'is_cool': True,
+            },
+            'number': 3,
+        }


### PR DESCRIPTION
Currently, hypernova render tokens are not properly replaced in escaped JSON response body. For example,
```
{"body": "<!--hypernova-render-token-abc123-->"}
```
can be encoded as 
```
'{"body": "\\u003c!--hypernova-render-token-abc123--\\u003e"}'
```
in which case the token replacement does not happen.

This PR adds logic for handling responses of `application/json` content type, which loads the JSON object into a dict, iteratively performs token replacements and updates the response with serialized, updated body.