### PR TITLE
Fix UnicodeDecodeError in tween for binary files

### DIFF
--- a/pyramid_hypernova/token_replacement.py
+++ b/pyramid_hypernova/token_replacement.py
@@ -21,7 +21,7 @@ def hypernova_token_replacement(hypernova_batch):
 
     :rtype: NoneType
     """
-    body = {'content': None}
+    body = {'content': ''}
 
     yield body
 

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -17,6 +17,9 @@ def hypernova_tween_factory(handler, registry):
 
         response = handler(request)
 
+        if request.hypernova_batch.jobs == {}:
+            return response
+
         try:
             # Skip token replacement logic if explicitly flagged to
             if request.disable_hypernova_tween:

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -17,7 +17,7 @@ def hypernova_tween_factory(handler, registry):
 
         response = handler(request)
 
-        if request.hypernova_batch.jobs == {}:
+        if not request.hypernova_batch.jobs:
             return response
 
         try:

--- a/tests/token_replacement_test.py
+++ b/tests/token_replacement_test.py
@@ -38,3 +38,14 @@ def test_hypernova_token_replacement_with_no_token():
 
     assert mock_hypernova_batch.submit.called
     assert body['content'] == content
+
+
+def test_hypernova_token_replacement_no_content_written_to_body():
+    mock_hypernova_batch = mock.Mock()
+    mock_hypernova_batch.submit.return_value = {}
+
+    with hypernova_token_replacement(mock_hypernova_batch) as body:
+        pass
+
+    assert mock_hypernova_batch.submit.called
+    assert body['content'] == ''


### PR DESCRIPTION
Currently the following line in `pyramid_hypernova/tweens.py` throws a `UnicodeDecodeError` for binary files: 
```
body['content'] = response.text
```

This PR changes it so that we return fast out of tween if there are no jobs in the hypernova batch, as no token replacement is necessary anyways. 