### PR TITLE
[Breaking] Add the Pyramid request object to the batch object

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -50,12 +50,13 @@ def create_job_groups(jobs, max_batch_size):
 
 class BatchRequest(object):
 
-    def __init__(self, batch_url, plugin_controller, max_batch_size=None, json_encoder=JSONEncoder()):
+    def __init__(self, batch_url, plugin_controller, pyramid_request, max_batch_size=None, json_encoder=JSONEncoder()):
         self.batch_url = batch_url
         self.jobs = {}
         self.plugin_controller = plugin_controller
         self.max_batch_size = max_batch_size
         self.json_encoder = json_encoder
+        self.pyramid_request = pyramid_request
 
     def render(self, name, data):
         identifier = str(uuid.uuid4())
@@ -152,7 +153,7 @@ class BatchRequest(object):
             synchronous = len(job_groups) == 1
 
             for job_group in job_groups:
-                request_headers = self.plugin_controller.transform_request_headers({})
+                request_headers = self.plugin_controller.transform_request_headers({}, self.pyramid_request)
                 query = HypernovaQuery(job_group, self.batch_url, self.json_encoder, synchronous, request_headers)
                 query.send()
                 queries.append((job_group, query))

--- a/pyramid_hypernova/plugins.py
+++ b/pyramid_hypernova/plugins.py
@@ -42,17 +42,18 @@ class PluginController(object):
             current_jobs = plugin.prepare_request(current_jobs, original_jobs)
         return current_jobs
 
-    def transform_request_headers(self, headers):
+    def transform_request_headers(self, headers, request):
         """A reducer type function that is called with the request headers that
         will be sent to Huypernova. Plugins can use this to inject request
         headers, e.g. to add distributed tracing headers (like Zipkin).
 
         :type headers: Dict[str, str]
         :returns: the modified headers to be submitted
+        :type request: a Pyramid request object
         :rtype: Dict[str, str]
         """
         for plugin in self.plugins:
-            headers = plugin.transform_request_headers(headers)
+            headers = plugin.transform_request_headers(headers, request)
         return headers
 
     def should_send_request(self, jobs):
@@ -140,12 +141,13 @@ class BasePlugin(object):
         """
         return current_jobs
 
-    def transform_request_headers(self, headers):
+    def transform_request_headers(self, headers, request):
         """A reducer type function that is called with the request headers that
-        will be sent to Huypernova. Plugins can use this to inject request
+        will be sent to Hypernova. Plugins can use this to inject request
         headers, e.g. to add distributed tracing headers (like Zipkin).
 
         :type headers: Dict[str, str]
+        :type request: a Pyramid request object
         :returns: the modified headers to be submitted
         :rtype: Dict[str, str]
         """

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -13,7 +13,7 @@ def hypernova_tween_factory(handler, registry):
     registry = registry
 
     def hypernova_tween(request):
-        request.hypernova_batch = configure_hypernova_batch(registry)
+        request.hypernova_batch = configure_hypernova_batch(registry, request)
 
         response = handler(request)
 
@@ -37,7 +37,7 @@ def hypernova_tween_factory(handler, registry):
     return hypernova_tween
 
 
-def configure_hypernova_batch(registry):
+def configure_hypernova_batch(registry, request):
     get_batch_url = registry.settings['pyramid_hypernova.get_batch_url']
 
     plugins = registry.settings.get('pyramid_hypernova.plugins', [])
@@ -54,4 +54,5 @@ def configure_hypernova_batch(registry):
         batch_url=get_batch_url(),
         plugin_controller=plugin_controller,
         json_encoder=json_encoder,
+        pyramid_request=request,
     )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 coverage
 mock
 pre-commit>=0.12.0
+pyramid
 pytest

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 from json import JSONEncoder
 
 import mock
+import pyramid.request
 import pytest
 
 from pyramid_hypernova.batch import BatchRequest
@@ -108,6 +109,7 @@ def batch_request(spy_plugin_controller, test_data, request):
     return BatchRequest(
         'http://localhost:8888',
         spy_plugin_controller,
+        pyramid_request=pyramid.request.Request.blank('/'),
         max_batch_size=request.param,
         json_encoder=json_encoder,
     )

--- a/tests/plugins_test.py
+++ b/tests/plugins_test.py
@@ -75,9 +75,10 @@ class TestPluginController(object):
         assert plugin_controller.should_send_request(jobs) is expected_value
 
     def test_transform_request_headers(self, plugins, plugin_controller):
-        plugins[0].transform_request_headers.side_effect = lambda x: dict(x, header1='yes')
-        plugins[1].transform_request_headers.side_effect = lambda x: dict(x, header2='yes')
-        assert plugin_controller.transform_request_headers({'foo': 'bar'}) == {
+        pyramid_request = mock.Mock()
+        plugins[0].transform_request_headers.side_effect = lambda x, r: dict(x, header1='yes')
+        plugins[1].transform_request_headers.side_effect = lambda x, r: dict(x, header2='yes')
+        assert plugin_controller.transform_request_headers({'foo': 'bar'}, pyramid_request) == {
             'foo': 'bar',
             'header1': 'yes',
             'header2': 'yes',
@@ -139,7 +140,8 @@ class TestBasePlugin(object):
 
     def test_transform_request_headers(self):
         plugin = BasePlugin()
-        assert plugin.transform_request_headers({'foo': 'bar'}) == {'foo': 'bar'}
+        pyramid_request = mock.Mock()
+        assert plugin.transform_request_headers({'foo': 'bar'}, pyramid_request) == {'foo': 'bar'}
 
     def test_should_send_request(self):
         plugin = BasePlugin()

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -54,6 +54,7 @@ class TestTweens(object):
             batch_url='http://localhost:8888/batch',
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
+            pyramid_request=self.mock_request,
         )
         assert self.mock_batch_request_factory.return_value.submit.called
         assert response.text == '<div>REACT!</div>'
@@ -67,6 +68,7 @@ class TestTweens(object):
             batch_url='http://localhost:8888/batch',
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
+            pyramid_request=self.mock_request,
         )
         assert self.mock_batch_request_factory.return_value.submit.called
         assert response.text == '<div>REACT!</div>'
@@ -80,6 +82,7 @@ class TestTweens(object):
             batch_url='http://localhost:8888/batch',
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
+            pyramid_request=self.mock_request,
         )
         assert not self.mock_batch_request_factory.return_value.submit.called
         assert response.text == str(self.token)


### PR DESCRIPTION
Fixes https://github.com/Yelp/pyramid-hypernova/issues/22.

Allows plugins to receive the request object in `transform_request_headers`.

**API Changes required to resolve this breaking change:**

- `pyramid_hypernova.batch_request_factory` now takes in a 4th argument, `pyramid_request`
- `BatchRequest` has a new 4th position argument, `pyramid_request`
- The `transform_request_headers` Plugin lifecycle method takes in a 2nd position argument, `pyramid_request`