### PR TITLE
Add context attribute to `render()` and the Job object

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -58,11 +58,14 @@ class BatchRequest(object):
         self.json_encoder = json_encoder
         self.pyramid_request = pyramid_request
 
-    def render(self, name, data):
+    def render(self, name, data, context=None):
+        if context is None:  # pragma: no cover
+            context = {}
+
         identifier = str(uuid.uuid4())
 
         data = self.plugin_controller.get_view_data(name, data)
-        job = Job(name, data)
+        job = Job(name, data, context)
         self.jobs[identifier] = job
 
         return RenderToken(identifier)

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -10,7 +10,7 @@ from requests.exceptions import HTTPError
 
 def create_jobs_payload(jobs):
     return {
-        identifier: {'name': job.name, 'data': job.data}
+        identifier: {'name': job.name, 'data': job.data, 'context': job.context}
         for identifier, job in jobs.items()
     }
 

--- a/pyramid_hypernova/types.py
+++ b/pyramid_hypernova/types.py
@@ -9,6 +9,10 @@ from collections import namedtuple
 Job = namedtuple('Job', (
     'name',
     'data',
+    # `context` is passed to pyramid-hypernova by consuming applications from the render function.
+    # It is forwarded verbatim to the Hypernova server, and can be used to pass extra arbitrary
+    # request or component level information.
+    'context',
 ))
 
 

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -23,10 +23,12 @@ test_jobs = {
     'some-unique-id': Job(
         name='FooBar.js',
         data={'baz': 1234},
+        context={},
     ),
     'some-other-unique-id': Job(
         name='MyComponent.js',
         data={'title': 'sup'},
+        context={},
     ),
 }
 
@@ -34,10 +36,12 @@ test_jobs_with_complex_numbers_in_data = {
     'some-unique-id': Job(
         name='FooBar.js',
         data={'baz': 1 + 2j},
+        context={},
     ),
     'some-other-unique-id': Job(
         name='MyComponent.js',
         data={'title': 3 + 4j},
+        context={},
     ),
 }
 
@@ -132,14 +136,17 @@ class TestBatchRequest(object):
             token_1.identifier: Job(
                 name='component-1.js',
                 data=data[0],
+                context={},
             ),
             token_2.identifier: Job(
                 name='component-2.js',
                 data=data[1],
+                context={},
             ),
             token_3.identifier: Job(
                 name='component-3.js',
                 data=data[2],
+                context={},
             ),
         }
 
@@ -178,17 +185,17 @@ class TestBatchRequest(object):
             token_1.identifier: JobResult(
                 error=None,
                 html='<div>component 1</div>',
-                job=Job(name='component-1.js', data=data[0])
+                job=Job(name='component-1.js', data=data[0], context={})
             ),
             token_2.identifier: JobResult(
                 error=None,
                 html='<div>component 2</div>',
-                job=Job(name='component-2.js', data=data[1])
+                job=Job(name='component-2.js', data=data[1], context={})
             ),
             token_3.identifier: JobResult(
                 error=None,
                 html='<div>component 3</div>',
-                job=Job(name='component-3.js', data=data[2])
+                job=Job(name='component-3.js', data=data[2], context={})
             ),
         }
 
@@ -208,7 +215,7 @@ class TestBatchRequest(object):
         data = test_data[0]
         token_1 = batch_request.render('MyComponent1.js', data[0])
         token_2 = batch_request.render('MyComponent2.js', data[1])
-        job_2 = Job(name='MyComponent2.js', data=data[1])
+        job_2 = Job(name='MyComponent2.js', data=data[1], context={})
 
         fake_response_json = {
             'error': None,
@@ -245,7 +252,7 @@ class TestBatchRequest(object):
             token_1.identifier: JobResult(
                 error=None,
                 html='<div>wow such SSR</div>',
-                job=Job(name='MyComponent1.js', data=data[0])
+                job=Job(name='MyComponent1.js', data=data[0], context={})
             ),
             token_2.identifier: JobResult(
                 error=HypernovaError(
@@ -266,7 +273,7 @@ class TestBatchRequest(object):
         mock_hypernova_query,
     ):
         data = test_data[0]
-        job = Job(name='MyComponent.js', data=data[0])
+        job = Job(name='MyComponent.js', data=data[0], context={})
         token = batch_request.render('MyComponent.js', data[0])
 
         fake_response_json = {
@@ -310,7 +317,7 @@ class TestBatchRequest(object):
         mock_hypernova_query,
     ):
         data = test_data[0]
-        job = Job(name='MyComponent.js', data=data[0])
+        job = Job(name='MyComponent.js', data=data[0], context={})
         token = batch_request.render('MyComponent.js', data[0])
 
         mock_hypernova_query.return_value.json.side_effect = HypernovaQueryError('oh no')

--- a/tests/rendering_test.py
+++ b/tests/rendering_test.py
@@ -36,7 +36,7 @@ def test_encode_with_custom_json_encoder():
 
 
 def test_render_blank_markup():
-    job = Job('MyCoolComponent.js', data={'title': 'sup'})
+    job = Job('MyCoolComponent.js', data={'title': 'sup'}, context={})
     markup = render_blank_markup('my-unique-token', job, False, JSONEncoder())
 
     assert markup == dedent('''
@@ -50,7 +50,7 @@ def test_render_blank_markup():
 
 
 def test_render_blank_markup_with_custom_json_encoder():
-    job = Job('MyCoolComponent.js', data={'a complex subject': 4.3 + 2.1j})
+    job = Job('MyCoolComponent.js', data={'a complex subject': 4.3 + 2.1j}, context={})
     markup = render_blank_markup('my-unique-token', job, False, ComplexJSONEncoder())
 
     assert markup == dedent('''
@@ -64,7 +64,7 @@ def test_render_blank_markup_with_custom_json_encoder():
 
 
 def test_render_blank_markup_with_error():
-    job = Job('MyCoolComponent.js', data={'title': 'sup'})
+    job = Job('MyCoolComponent.js', data={'title': 'sup'}, context={})
     markup = render_blank_markup('my-unique-token', job, True, JSONEncoder())
 
     assert markup == dedent('''

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -15,8 +15,8 @@ from pyramid_hypernova.request import HypernovaQueryError
 from pyramid_hypernova.types import Job
 
 TEST_JOB_GROUP = {
-    'yellow keycard': Job('open the exit door', 'behind the cacodemon'),
-    'red skull key': Job('get the bfg9k', 'rocket jump from the platform'),
+    'yellow keycard': Job('open the exit door', 'behind the cacodemon', {}),
+    'red skull key': Job('get the bfg9k', 'rocket jump from the platform', {'foo': 'bar'}),
 }
 
 
@@ -39,10 +39,12 @@ def test_create_jobs_payload():
         'yellow keycard': {
             'name': 'open the exit door',
             'data': 'behind the cacodemon',
+            'context': {},
         },
         'red skull key': {
             'name': 'get the bfg9k',
             'data': 'rocket jump from the platform',
+            'context': {'foo': 'bar'},
         }
     }
 


### PR DESCRIPTION
This allows us to pass extra request/component level information to the hypernova server, without being sneaky and using headers, or stuffing it into the request string.

This will be released as a breaking change since we're changing the interface to `Job`, but should be a 'safe' bump for most users, as we set a default param on the publicly consumed `render` method