### PR TITLE
[breaking] Pass pyramid request to on_error lifecycle hook

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -86,7 +86,7 @@ class BatchRequest(object):
                     message=result['error']['message'],
                     stack=result['error']['stack'],
                 )
-                self.plugin_controller.on_error(error, {identifier: job})
+                self.plugin_controller.on_error(error, {identifier: job}, self.pyramid_request)
 
             html = result['html']
             if not html:
@@ -117,7 +117,7 @@ class BatchRequest(object):
                     stack=response_json['error']['stack'],
                 )
                 pyramid_response = create_fallback_response(jobs, True, self.json_encoder, error)
-                self.plugin_controller.on_error(error, jobs)
+                self.plugin_controller.on_error(error, jobs, self.pyramid_request)
             else:
                 pyramid_response = self._parse_response(response_json)
                 self.plugin_controller.on_success(pyramid_response, jobs)
@@ -131,7 +131,7 @@ class BatchRequest(object):
                 str(e),
                 [line.rstrip('\n') for line in traceback.format_tb(exc_traceback)],
             )
-            self.plugin_controller.on_error(error, jobs)
+            self.plugin_controller.on_error(error, jobs, self.pyramid_request)
             pyramid_response = create_fallback_response(jobs, True, self.json_encoder, error)
 
         return pyramid_response

--- a/pyramid_hypernova/plugins.py
+++ b/pyramid_hypernova/plugins.py
@@ -100,15 +100,16 @@ class PluginController(object):
         for plugin in self.plugins:
             plugin.on_success(response, jobs)
 
-    def on_error(self, err, jobs):
+    def on_error(self, err, jobs, request):
         """An event type function that is called whenever any error is
         encountered
 
         :type err: dict
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         """
         for plugin in self.plugins:
-            plugin.on_error(err, jobs)
+            plugin.on_error(err, jobs, request)
 
 
 class BasePlugin(object):
@@ -191,10 +192,11 @@ class BasePlugin(object):
         :type jobs: Dict[str, Job]
         """
 
-    def on_error(self, err, jobs):
+    def on_error(self, err, jobs, request):
         """An event type function that is called whenever any error is
         encountered
 
         :type err: dict
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         """

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -466,6 +466,7 @@ class TestBatchRequestLifecycleMethods(object):
                 stack=[],
             ),
             batch_request.jobs,
+            batch_request.pyramid_request
         )
 
     def test_calls_on_error_on_unhealthy_service(
@@ -495,4 +496,5 @@ class TestBatchRequestLifecycleMethods(object):
                 stack=['Traceback:', '  foo:'],
             ),
             batch_request.jobs,
+            batch_request.pyramid_request
         )

--- a/tests/plugins_test.py
+++ b/tests/plugins_test.py
@@ -116,9 +116,11 @@ class TestPluginController(object):
     def test_on_error(self, plugins, plugin_controller):
         err = mock.Mock()
         jobs = mock.Mock()
-        plugin_controller.on_error(err, jobs)
-        plugins[0].on_error.assert_called_once_with(err, jobs)
-        plugins[1].on_error.assert_called_once_with(err, jobs)
+        pyramid_request = mock.Mock()
+
+        plugin_controller.on_error(err, jobs, pyramid_request)
+        plugins[0].on_error.assert_called_once_with(err, jobs, pyramid_request)
+        plugins[1].on_error.assert_called_once_with(err, jobs, pyramid_request)
 
 
 class TestBasePlugin(object):


### PR DESCRIPTION
This introduces a third parameter to `BasePlugin::on_error` so that plugins can access an instance of the `Pyramid Request` object.

This is a breaking change, since this modifies the `pyramid_hypernova` plugin interface for
`on_error` callbacks.

To get past this breaking change, your `on_error` callback can take in an additional `request` parameter, like so:

```python
class MyPlugin(BasePlugin):

     def on_error(self, err, jobs, request):
               ...

```