### PR TITLE
Made changes for should_send_request to take in pyramid request object

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -145,7 +145,7 @@ class BatchRequest(object):
 
         response = {}
 
-        if self.jobs and self.plugin_controller.should_send_request(self.jobs):
+        if self.jobs and self.plugin_controller.should_send_request(self.jobs, self.pyramid_request):
             self.plugin_controller.will_send_request(self.jobs)
             job_groups = create_job_groups(self.jobs, self.max_batch_size)
             queries = []

--- a/pyramid_hypernova/plugins.py
+++ b/pyramid_hypernova/plugins.py
@@ -13,33 +13,35 @@ class PluginController(object):
     def __init__(self, plugins):
         self.plugins = plugins
 
-    def get_view_data(self, view_name, data):
+    def get_view_data(self, view_name, data, request):
         """Allows you to alter the data that a "view" will receive
 
         :param view_name: the name of the component
         :type view_name: string
         :param data: the props that will be passed into the component
         :type data: any
+        :type request: a Pyramid request object
         :returns: the new data
         :rtype: any
         """
         for plugin in self.plugins:
-            data = plugin.get_view_data(view_name, data)
+            data = plugin.get_view_data(view_name, data, request)
         return data
 
-    def prepare_request(self, jobs):
+    def prepare_request(self, jobs, request):
         """A reducer type function that is called when preparing the request
         that will be sent to Hypernova. This function receives the current
         running jobs Object and the original jobs Object.
 
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         :returns: the modified Jobs to be submitted
         :rtype: Dict[str, Job]
         """
         current_jobs = jobs
         original_jobs = jobs
         for plugin in self.plugins:
-            current_jobs = plugin.prepare_request(current_jobs, original_jobs)
+            current_jobs = plugin.prepare_request(current_jobs, original_jobs, request)
         return current_jobs
 
     def transform_request_headers(self, headers, request):
@@ -67,39 +69,42 @@ class PluginController(object):
         """
         return all(plugin.should_send_request(jobs, request) for plugin in self.plugins)
 
-    def will_send_request(self, jobs):
+    def will_send_request(self, jobs, request):
         """An event type function that is called prior to a request being sent.
 
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         """
         for plugin in self.plugins:
-            plugin.will_send_request(jobs)
+            plugin.will_send_request(jobs, request)
 
-    def after_response(self, response):
+    def after_response(self, response, request):
         """A reducer type function which receives the current response and
         the original response from the Hypernova service.
 
         :param response: a response dict, as returned by
             `parse_response`
         :type response: dict
+        :type request: a Pyramid request object
         :returns: the new response value
         :rtype: any
         """
         current_response = response
         original_response = response
         for plugin in self.plugins:
-            current_response = plugin.after_response(current_response, original_response)
+            current_response = plugin.after_response(current_response, original_response, request)
         return current_response
 
-    def on_success(self, response, jobs):
+    def on_success(self, response, jobs, request):
         """An event type function that is called whenever a request was
         successful.
 
         :type response: dict
+        :type request: a Pyramid request object
         :type jobs: Dict[str, Job]
         """
         for plugin in self.plugins:
-            plugin.on_success(response, jobs)
+            plugin.on_success(response, jobs, request)
 
     def on_error(self, err, jobs, request):
         """An event type function that is called whenever any error is
@@ -119,25 +124,27 @@ class BasePlugin(object):
     See https://github.com/airbnb/hypernova/blob/master/docs/client-spec.md
     """
 
-    def get_view_data(self, view_name, data):
+    def get_view_data(self, view_name, data, request):
         """Allows you to alter the data that a "view" will receive
 
         :param view_name: the name of the component
         :type view_name: string
         :param data: the props that will be passed into the component
         :type data: any
+        :type request: a Pyramid request object
         :returns: the new data
         :rtype: any
         """
         return data
 
-    def prepare_request(self, current_jobs, original_jobs):
+    def prepare_request(self, current_jobs, original_jobs, request):
         """A reducer type function that is called when preparing the request
         that will be sent to Hypernova. This function receives the current
         running jobs Object and the original jobs Object.
 
         :type current_jobs: Dict[str, Job]
         :type original_jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         :returns: the modified Jobs to be submitted
         :rtype: Dict[str, Job]
         """
@@ -166,13 +173,14 @@ class BasePlugin(object):
         """
         return True
 
-    def will_send_request(self, jobs):
+    def will_send_request(self, jobs, request):
         """An event type function that is called prior to a request being sent.
 
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         """
 
-    def after_response(self, current_response, original_response):
+    def after_response(self, current_response, original_response, request):
         """A reducer type function which receives the current response and
         the original response from the Hypernova service.
 
@@ -181,17 +189,19 @@ class BasePlugin(object):
         :param original_response: a response dict, as returned by
             `parse_response`
         :type original_response: dict
+        :type request: a Pyramid request object
         :returns: the new response value
         :rtype: any
         """
         return current_response
 
-    def on_success(self, response, jobs):
+    def on_success(self, response, jobs, request):
         """An event type function that is called whenever a request was
         successful.
 
         :type response: dict
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         """
 
     def on_error(self, err, jobs, request):

--- a/pyramid_hypernova/plugins.py
+++ b/pyramid_hypernova/plugins.py
@@ -56,15 +56,16 @@ class PluginController(object):
             headers = plugin.transform_request_headers(headers, request)
         return headers
 
-    def should_send_request(self, jobs):
+    def should_send_request(self, jobs, request):
         """An every type function. If one returns false then the request is
         canceled.
 
         :type jobs: Dict[str, Job]
         :returns: False if the request should be cancelled
+        :type request: a Pyramid request object
         :rtype: bool
         """
-        return all(plugin.should_send_request(jobs) for plugin in self.plugins)
+        return all(plugin.should_send_request(jobs, request) for plugin in self.plugins)
 
     def will_send_request(self, jobs):
         """An event type function that is called prior to a request being sent.
@@ -154,11 +155,12 @@ class BasePlugin(object):
         """
         return headers
 
-    def should_send_request(self, jobs):
+    def should_send_request(self, jobs, request):
         """An every type function. If one returns false then the request is
         canceled.
 
         :type jobs: Dict[str, Job]
+        :type request: a Pyramid request object
         :returns: False if the request should be cancelled
         :rtype: bool
         """

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -358,6 +358,7 @@ class TestBatchRequestLifecycleMethods(object):
         spy_plugin_controller.get_view_data.assert_called_once_with(
             'MyComponent.js',
             data[0],
+            batch_request.pyramid_request,
         )
 
         job = batch_request.jobs[token.identifier]
@@ -365,22 +366,18 @@ class TestBatchRequestLifecycleMethods(object):
         assert job.data == spy_plugin_controller.get_view_data(
             'MyComponent.js',
             data[0],
+            batch_request.pyramid_request,
         )
 
     def test_calls_prepare_request(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
         batch_request.render('MySsrComponent.js', data[0])
 
-        original_jobs = dict(batch_request.jobs)
-
         batch_request.submit()
 
-        spy_plugin_controller.prepare_request.assert_has_calls([
-            mock.call(original_jobs),
-        ])
-
-        assert batch_request.jobs == spy_plugin_controller.prepare_request(
-            original_jobs
+        spy_plugin_controller.prepare_request.assert_called_once_with(
+            batch_request.jobs,
+            batch_request.pyramid_request
         )
 
     def test_calls_will_send_request(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
@@ -389,9 +386,10 @@ class TestBatchRequestLifecycleMethods(object):
 
         batch_request.submit()
 
-        spy_plugin_controller.will_send_request.assert_has_calls([
-            mock.call(batch_request.jobs),
-        ])
+        spy_plugin_controller.will_send_request.assert_called_once_with(
+            batch_request.jobs,
+            batch_request.pyramid_request,
+        )
 
     def test_calls_after_response(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
@@ -420,7 +418,7 @@ class TestBatchRequestLifecycleMethods(object):
             ),
         }
 
-        assert response == spy_plugin_controller.after_response(parsed_response)
+        assert response == spy_plugin_controller.after_response(parsed_response, batch_request.pyramid_request)
 
     def test_calls_on_success(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
@@ -442,6 +440,7 @@ class TestBatchRequestLifecycleMethods(object):
         spy_plugin_controller.on_success.assert_called_once_with(
             response,
             batch_request.jobs,
+            batch_request.pyramid_request,
         )
 
     def test_calls_on_error(self, spy_plugin_controller, test_data, batch_request, mock_hypernova_query):

--- a/tests/plugins_test.py
+++ b/tests/plugins_test.py
@@ -21,33 +21,41 @@ def plugin_controller(plugins):
 
 class TestPluginController(object):
     def test_get_view_data(self, plugins, plugin_controller):
+        pyramid_request = mock.Mock()
+
         data = plugin_controller.get_view_data(
             'MyComponent.js',
             {'title': 'sup'},
+            pyramid_request,
         )
 
         plugins[0].get_view_data.assert_called_once_with(
             'MyComponent.js',
             {'title': 'sup'},
+            pyramid_request,
         )
         plugins[1].get_view_data.assert_called_once_with(
             'MyComponent.js',
             plugins[0].get_view_data.return_value,
+            pyramid_request,
         )
         assert data == plugins[1].get_view_data.return_value
 
     def test_prepare_request(self, plugins, plugin_controller):
         original_jobs = [mock.Mock()]
+        pyramid_request = mock.Mock()
 
-        jobs = plugin_controller.prepare_request(original_jobs)
+        jobs = plugin_controller.prepare_request(original_jobs, pyramid_request)
 
         plugins[0].prepare_request.assert_called_once_with(
             original_jobs,
             original_jobs,
+            pyramid_request
         )
         plugins[1].prepare_request.assert_called_once_with(
             plugins[0].prepare_request.return_value,
             original_jobs,
+            pyramid_request
         )
 
         assert jobs == plugins[1].prepare_request.return_value
@@ -87,22 +95,26 @@ class TestPluginController(object):
 
     def test_will_send_request(self, plugins, plugin_controller):
         jobs = mock.Mock()
-        plugin_controller.will_send_request(jobs)
-        plugins[0].will_send_request.assert_called_once_with(jobs)
-        plugins[1].will_send_request.assert_called_once_with(jobs)
+        pyramid_request = mock.Mock()
+        plugin_controller.will_send_request(jobs, pyramid_request)
+        plugins[0].will_send_request.assert_called_once_with(jobs, pyramid_request)
+        plugins[1].will_send_request.assert_called_once_with(jobs, pyramid_request)
 
     def test_after_response(self, plugins, plugin_controller):
         original_response = mock.Mock()
+        pyramid_request = mock.Mock()
 
-        response = plugin_controller.after_response(original_response)
+        response = plugin_controller.after_response(original_response, pyramid_request)
 
         plugins[0].after_response.assert_called_once_with(
             original_response,
             original_response,
+            pyramid_request,
         )
         plugins[1].after_response.assert_called_once_with(
             plugins[0].after_response.return_value,
             original_response,
+            pyramid_request,
         )
 
         assert response == plugins[1].after_response.return_value
@@ -110,9 +122,10 @@ class TestPluginController(object):
     def test_on_success(self, plugins, plugin_controller):
         response = mock.Mock()
         jobs = mock.Mock()
-        plugin_controller.on_success(response, jobs)
-        plugins[0].on_success.assert_called_once_with(response, jobs)
-        plugins[1].on_success.assert_called_once_with(response, jobs)
+        pyramid_request = mock.Mock()
+        plugin_controller.on_success(response, jobs, pyramid_request)
+        plugins[0].on_success.assert_called_once_with(response, jobs, pyramid_request)
+        plugins[1].on_success.assert_called_once_with(response, jobs, pyramid_request)
 
     def test_on_error(self, plugins, plugin_controller):
         err = mock.Mock()
@@ -130,15 +143,18 @@ class TestBasePlugin(object):
     def test_get_view_data(self):
         plugin = BasePlugin()
         data = mock.sentinel.data
-        assert plugin.get_view_data('MyComponent.js', data) == data
+        pyramid_request = mock.Mock()
+        assert plugin.get_view_data('MyComponent.js', data, pyramid_request) == data
 
     def test_prepare_request(self):
         plugin = BasePlugin()
         current_jobs = mock.sentinel.current_jobs
         original_jobs = mock.sentinel.original_jobs
+        pyramid_request = mock.Mock()
         assert plugin.prepare_request(
             current_jobs,
             original_jobs,
+            pyramid_request
         ) == current_jobs
 
     def test_transform_request_headers(self):
@@ -156,7 +172,9 @@ class TestBasePlugin(object):
         plugin = BasePlugin()
         current_response = mock.sentinel.current_response
         original_response = mock.sentinel.original_response
+        pyramid_request = mock.Mock()
         assert plugin.after_response(
             current_response,
             original_response,
+            pyramid_request,
         ) == current_response

--- a/tests/plugins_test.py
+++ b/tests/plugins_test.py
@@ -69,10 +69,11 @@ class TestPluginController(object):
         plugin_1_return_value,
         expected_value
     ):
+        pyramid_request = mock.Mock()
         plugins[0].should_send_request.return_value = plugin_0_return_value
         plugins[1].should_send_request.return_value = plugin_1_return_value
         jobs = mock.Mock()
-        assert plugin_controller.should_send_request(jobs) is expected_value
+        assert plugin_controller.should_send_request(jobs, pyramid_request) is expected_value
 
     def test_transform_request_headers(self, plugins, plugin_controller):
         pyramid_request = mock.Mock()
@@ -146,9 +147,10 @@ class TestBasePlugin(object):
         assert plugin.transform_request_headers({'foo': 'bar'}, pyramid_request) == {'foo': 'bar'}
 
     def test_should_send_request(self):
+        pyramid_request = mock.Mock()
         plugin = BasePlugin()
         jobs = mock.sentinel.jobs
-        assert plugin.should_send_request(jobs)
+        assert plugin.should_send_request(jobs, pyramid_request)
 
     def test_after_response(self):
         plugin = BasePlugin()


### PR DESCRIPTION
should_send_request now takes the pyramid-request object. This is in regards to ticket https://jira.yelpcorp.com/browse/ROOTS-899 to implement client side rendering. With the pyramid-request object, one can look at the request url or other values to determine whether the request for Server Side Rendering should be sent. One issue I see with this is that as this is an open source package, anyone who uses should_send_request would need to update their version to pass in the pyramid-request object into the method. This could be curtailed by setting request=None as a default value for the parameter.. Don't know if this is necessary.