### PR TITLE
Update BatchRequest batch_url to get_job_group_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [8.0.0] - 2021-04-16
+
+### Changed
+
+`BatchRequest` now accepts a function, `get_job_group_url`, in place of `batch_url`. This allows for increased flexibility in routing hypernova requests.
+
+You'll need to update your `pyramid_hypernova.get_batch_url` to the `pyramid_hypernova.get_job_group_url` setting.
+
+Before:
+```py
+def get_batch_url():
+    return 'https://localhost:8080/batch'
+
+registry.settings.update({
+    'pyramid_hypernova.get_batch_url': get_batch_url,
+})
+```
+
+After:
+```py
+def get_job_group_url():
+    return 'https://localhost:8080/batch'
+
+registry.settings.update({
+    'pyramid_hypernova.get_job_group_url': get_job_group_url,
+})
+```
+
+-----
+
+Additionally, If you were manually supplying a BatchRequest factory via the `pyramid_hypernova.batch_request_factory` setting, you'll need
+to update its API to accept `get_job_group_url` and pass it along to the `BatchRequest` class. Example:
+
+Before:
+```py
+def batch_request_factory(batch_url, plugin_controller, json_encoder, pyramid_request):
+    return BatchRequest(
+        batch_url=batch_url,
+        plugin_controller=plugin_controller,
+        json_encoder=json_encoder,
+        pyramid_request=pyramid_request,
+    )
+
+registry.settings.update({
+    'pyramid_hypernova.batch_request_factory': batch_request_factory,
+})
+```
+
+After:
+```py
+def batch_request_factory(get_job_group_url, plugin_controller, json_encoder, pyramid_request):
+    return BatchRequest(
+        get_job_group_url=get_job_group_url,
+        plugin_controller=plugin_controller,
+        json_encoder=json_encoder,
+        pyramid_request=pyramid_request,
+    )
+
+registry.settings.update({
+    'pyramid_hypernova.batch_request_factory': batch_request_factory,
+})
+```
+
+`get_job_group_url` will be supplied two parameters - the **job group** that pyramid_hypernova will be making a request for and the **pyramid request**:
+
+```py
+def get_batch_url(job_group, pyramid_request): ...
+```
+
+This will be called right before send _on every job group request_. If you're doing an expensive operation to retrieve this url, consider memoizing it.

--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -50,8 +50,15 @@ def create_job_groups(jobs, max_batch_size):
 
 class BatchRequest(object):
 
-    def __init__(self, batch_url, plugin_controller, pyramid_request, max_batch_size=None, json_encoder=JSONEncoder()):
-        self.batch_url = batch_url
+    def __init__(
+        self,
+        get_job_group_url,
+        plugin_controller,
+        pyramid_request,
+        max_batch_size=None,
+        json_encoder=JSONEncoder()
+    ):
+        self.get_job_group_url = get_job_group_url
         self.jobs = {}
         self.plugin_controller = plugin_controller
         self.max_batch_size = max_batch_size
@@ -156,8 +163,9 @@ class BatchRequest(object):
             synchronous = len(job_groups) == 1
 
             for job_group in job_groups:
+                batch_url = self.get_job_group_url(job_group, self.pyramid_request)
                 request_headers = self.plugin_controller.transform_request_headers({}, self.pyramid_request)
-                query = HypernovaQuery(job_group, self.batch_url, self.json_encoder, synchronous, request_headers)
+                query = HypernovaQuery(job_group, batch_url, self.json_encoder, synchronous, request_headers)
                 query.send()
                 queries.append((job_group, query))
 

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -38,7 +38,7 @@ def hypernova_tween_factory(handler, registry):
 
 
 def configure_hypernova_batch(registry, request):
-    get_batch_url = registry.settings['pyramid_hypernova.get_batch_url']
+    get_job_group_url = registry.settings['pyramid_hypernova.get_job_group_url']
 
     plugins = registry.settings.get('pyramid_hypernova.plugins', [])
     plugin_controller = PluginController(plugins)
@@ -51,7 +51,7 @@ def configure_hypernova_batch(registry, request):
     json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', JSONEncoder())
 
     return batch_request_factory(
-        batch_url=get_batch_url(),
+        get_job_group_url=get_job_group_url,
         plugin_controller=plugin_controller,
         json_encoder=json_encoder,
         pyramid_request=request,

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -21,7 +21,7 @@ class TestTweens(object):
             text=str(self.token)
         )
 
-        mock_get_batch_url = mock.Mock(return_value='http://localhost:8888/batch')
+        self.mock_get_job_group_url = mock.Mock(return_value='http://localhost:8888/batch')
 
         self.mock_json_encoder = mock.Mock()
 
@@ -36,7 +36,7 @@ class TestTweens(object):
 
         self.mock_registry = mock.Mock()
         self.mock_registry.settings = {
-            'pyramid_hypernova.get_batch_url': mock_get_batch_url,
+            'pyramid_hypernova.get_job_group_url': self.mock_get_job_group_url,
             'pyramid_hypernova.batch_request_factory': self.mock_batch_request_factory,
             'pyramid_hypernova.json_encoder': self.mock_json_encoder,
         }
@@ -51,7 +51,7 @@ class TestTweens(object):
         response = self.tween(self.mock_request)
 
         self.mock_batch_request_factory.assert_called_once_with(
-            batch_url='http://localhost:8888/batch',
+            get_job_group_url=self.mock_get_job_group_url,
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,
@@ -65,7 +65,7 @@ class TestTweens(object):
         response = self.tween(self.mock_request)
 
         self.mock_batch_request_factory.assert_called_once_with(
-            batch_url='http://localhost:8888/batch',
+            get_job_group_url=self.mock_get_job_group_url,
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,
@@ -79,7 +79,7 @@ class TestTweens(object):
         response = self.tween(self.mock_request)
 
         self.mock_batch_request_factory.assert_called_once_with(
-            batch_url='http://localhost:8888/batch',
+            get_job_group_url=self.mock_get_job_group_url,
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,


### PR DESCRIPTION
This is a __breaking change__ that gives us more flexibility when configuring the URL that pyramid-hypernova hits to make a hypernova render request. I've updated `BatchRequest` to pass through the configured `get_job_group_url` (replaces `get_batch_url`) helper up until the time right before the request is made. `get_job_group_url` will be passed the job group and pyramid request so we can dynamically configure the URL for each hypernova request. This opens up possibilities for instance sharding.

Also added a CHANGELOG.md file to document this change and how to migrate.