### PR TITLE
Update and fix documentation for get_job_group_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ registry.settings.update({
 
 After:
 ```py
-def get_job_group_url():
+def get_job_group_url(job_group, pyramid_request):
     return 'https://localhost:8080/batch'
 
 registry.settings.update({
@@ -72,7 +72,7 @@ registry.settings.update({
 `get_job_group_url` will be supplied two parameters - the **job group** that pyramid_hypernova will be making a request for and the **pyramid request**:
 
 ```py
-def get_batch_url(job_group, pyramid_request): ...
+def get_job_group_url(job_group, pyramid_request): ...
 ```
 
 This will be called right before send _on every job group request_. If you're doing an expensive operation to retrieve this url, consider memoizing it.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Usage
 In your service's Pyramid configuration (e.g. `webapp.py`), you can configure the Pyramid tween like so:
 
 ```python
-def get_batch_url():
+def get_job_group_url(job_group, pyramid_request):
     return 'https://localhost:8080/batch'
 
-config.registry.settings['pyramid_hypernova.get_batch_url'] = get_batch_url
+config.registry.settings['pyramid_hypernova.get_job_group_url'] = get_job_group_url
 config.add_tween('pyramid_hypernova.tweens.hypernova_tween_factory')
 ```
 


### PR DESCRIPTION
The documentation in the README was outdated, and the instructions
to update to 8.0.0 needed some tweaks.