### PR TITLE
Return fallback request when there's no healthy SSR upstream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import setup
 
 setup(
     name='pyramid-hypernova',
-    version='8.0.0',
+    version='8.0.1',
     author='Yelp, Inc.',
     author_email='opensource+pyramid-hypernova@yelp.com',
     license='MIT',


### PR DESCRIPTION
if there's no healthy SSR host, `requests.post()` throws an error. we catch errors that are thrown in `.json()` (e.g. by `raise_for_status()`) and return a fallback response when they happen, which is why we show fallbacks when there's an upstream timeout, but if `.send()` errors, we freak out and return an error code instead. this PR moves the `requests.post()` call to `.json()` instead, so that we can catch these errors and return our fallback response. this will not affect anything else because nothing but `HypernovaQuery` tries to access `self.response`, so it not being there after running `send()` won't affect anything.

unit tests included.