### PR TITLE
Drop python2.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,45 +1,33 @@
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    sha: v0.7.1
-    hooks:
-    -   id: trailing-whitespace
-        language_version: python3.7
-    -   id: end-of-file-fixer
-        language_version: python3.7
-        exclude: ^\.activate\.sh$
-    -   id: autopep8-wrapper
-        language_version: python3.7
-    -   id: check-docstring-first
-        language_version: python3.7
-    -   id: check-merge-conflict
-        language_version: python3.7
-    -   id: check-yaml
-        language_version: python3.7
-    -   id: debug-statements
-        language_version: python3.7
-    -   id: double-quote-string-fixer
-        language_version: python3.7
-    -   id: name-tests-test
-        language_version: python3.7
-    -   id: flake8
-        language_version: python3.7
-    -   id: check-added-large-files
-        language_version: python3.7
-        exclude: ^\.activate\.sh$
-    -   id: check-byte-order-marker
-        language_version: python3.7
-    -   id: fix-encoding-pragma
-        language_version: python3.7
--   repo: https://github.com/asottile/reorder_python_imports
-    sha: v0.3.1
-    hooks:
-    -   id: reorder-python-imports
-        language_version: python3.7
-        args: [
-            '--add-import', 'from __future__ import absolute_import',
-            '--add-import', 'from __future__ import unicode_literals',
-        ]
--   repo: https://github.com/asottile/pyupgrade
-    sha: v1.0.6
-    hooks:
-    -   id: pyupgrade
-        language_version: python3.7
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.3.0
+      hooks:
+          - id: trailing-whitespace
+          - id: end-of-file-fixer
+            exclude: ^\.activate\.sh$
+          - id: check-docstring-first
+          - id: check-merge-conflict
+          - id: check-yaml
+          - id: debug-statements
+          - id: double-quote-string-fixer
+          - id: name-tests-test
+          - id: check-added-large-files
+            exclude: ^\.activate\.sh$
+          - id: check-byte-order-marker
+    - repo: https://github.com/pre-commit/mirrors-autopep8
+      rev: v1.7.0
+      hooks:
+          - id: autopep8
+    - repo: https://github.com/PyCQA/flake8
+      rev: 5.0.4
+      hooks:
+          - id: flake8
+    - repo: https://github.com/asottile/reorder_python_imports
+      rev: v3.8.2
+      hooks:
+          - id: reorder-python-imports
+    - repo: https://github.com/asottile/pyupgrade
+      rev: v2.37.3
+      hooks:
+          - id: pyupgrade
+            args: ['--py37-plus']

--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import sys
 import traceback
 import uuid
@@ -48,7 +44,7 @@ def create_job_groups(jobs, max_batch_size):
     return job_groups
 
 
-class BatchRequest(object):
+class BatchRequest:
 
     def __init__(
         self,

--- a/pyramid_hypernova/plugins.py
+++ b/pyramid_hypernova/plugins.py
@@ -1,9 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
-
-class PluginController(object):
+class PluginController:
     """A controller that coordinates calling hook methods of any registered
     plugins.
 
@@ -118,7 +113,7 @@ class PluginController(object):
             plugin.on_error(err, jobs, request)
 
 
-class BasePlugin(object):
+class BasePlugin:
     """A trivial base plugin that doesn't do anything.
 
     See https://github.com/airbnb/hypernova/blob/master/docs/client-spec.md

--- a/pyramid_hypernova/rendering.py
+++ b/pyramid_hypernova/rendering.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import re
 from textwrap import dedent
 
@@ -63,7 +58,7 @@ def render_blank_markup(identifier, job, throw_client_error, json_encoder):
     return blank_markup
 
 
-class RenderToken(object):
+class RenderToken:
     """A placeholder for a Hypernova job that can later be replaced by the
     rendered component.
 
@@ -77,7 +72,7 @@ class RenderToken(object):
 
     def __html__(self):
         """Custom HTML markup for templating languages that use markupsafe."""
-        return '<!--hypernova-render-token-{}-->'.format(self.identifier)
+        return f'<!--hypernova-render-token-{self.identifier}-->'
 
     def __str__(self):
         return self.__html__()

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import fido
 import requests
 from fido.exceptions import NetworkError
@@ -18,10 +14,10 @@ def create_jobs_payload(jobs):
 
 class HypernovaQueryError(Exception):
     def __init__(self, child_error):
-        super(HypernovaQueryError, self).__init__(str(child_error))
+        super().__init__(str(child_error))
 
 
-class HypernovaQuery(object):
+class HypernovaQuery:
     """ Abstract Hypernova query """
 
     def __init__(self, job_group, url, json_encoder, synchronous, request_headers):

--- a/pyramid_hypernova/token_replacement.py
+++ b/pyramid_hypernova/token_replacement.py
@@ -7,7 +7,7 @@ from pyramid_hypernova.rendering import RenderToken
 def hypernova_token_replacement(hypernova_batch):
     """A context manager that performs hypernova token replacement in a batch.
     Write the content you wish to modify in body['content'] where body is the
-    yielded dict. Written content must be of unicode type in py2 and str in py3.
+    yielded dict. Written content must be str in py3.
 
     Example usage:
         with hypernova_token_replacement(hypernova_batch) as body:

--- a/pyramid_hypernova/token_replacement.py
+++ b/pyramid_hypernova/token_replacement.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from contextlib import contextmanager
 
 from pyramid_hypernova.rendering import RenderToken

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from json import JSONEncoder
 
 from pyramid_hypernova.batch import BatchRequest

--- a/pyramid_hypernova/types.py
+++ b/pyramid_hypernova/types.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import namedtuple
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 coverage
-mock
 pre-commit>=0.12.0
 pyramid
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[wheel]
-universal = True

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from setuptools import find_packages
 from setuptools import setup
 
@@ -15,12 +11,11 @@ setup(
     url='https://github.com/Yelp/pyramid-hypernova',
     description="A Python client for Airbnb's Hypernova server, for use with the Pyramid web framework.",
     classifiers=[
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
+    python_requires='>=3.7',
     install_requires=[
         'fido',
         'more-itertools',

--- a/testing/json_encoder.py
+++ b/testing/json_encoder.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import json
 
 

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from json import JSONEncoder
+from unittest import mock
 
-import mock
 import pyramid.request
 import pytest
 
@@ -130,7 +126,7 @@ def mock_hypernova_query():
         yield mock_hypernova_query
 
 
-class TestBatchRequest(object):
+class TestBatchRequest:
 
     def test_successful_batch_request(self, spy_get_job_group_url, test_data, batch_request, mock_hypernova_query):
         data = test_data[0]
@@ -355,7 +351,7 @@ class TestBatchRequest(object):
         }
 
 
-class TestBatchRequestLifecycleMethods(object):
+class TestBatchRequestLifecycleMethods:
     """Test that BatchRequest calls plugin lifecycle methods at the
     appropriate times.
     """

--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -175,7 +175,7 @@ class TestBatchRequest:
         if batch_request.max_batch_size is None:
             assert spy_get_job_group_url.call_count == 1
             # get_job_group_url is supplied with the job group
-            assert len(spy_get_job_group_url.mock_calls[0].args[0]) == 3
+            assert len(spy_get_job_group_url.mock_calls[0]) == 3
             assert mock_hypernova_query.call_count == 1
         else:
             # Division (rounded-up) up to get total number of calls

--- a/tests/plugins_test.py
+++ b/tests/plugins_test.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from unittest import mock
 
-import mock
 import pytest
 
 from pyramid_hypernova.plugins import BasePlugin
@@ -19,7 +16,7 @@ def plugin_controller(plugins):
     return PluginController(plugins)
 
 
-class TestPluginController(object):
+class TestPluginController:
     def test_get_view_data(self, plugins, plugin_controller):
         pyramid_request = mock.Mock()
 
@@ -137,7 +134,7 @@ class TestPluginController(object):
         plugins[1].on_error.assert_called_once_with(err, jobs, pyramid_request)
 
 
-class TestBasePlugin(object):
+class TestBasePlugin:
     """Reducer functions on the BasePlugin should be identity functions."""
 
     def test_get_view_data(self):

--- a/tests/rendering_test.py
+++ b/tests/rendering_test.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from json import JSONEncoder
 from textwrap import dedent
 

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 from json import JSONEncoder
+from unittest import mock
 
-import mock
 import pytest
 from fido.exceptions import NetworkError
 from requests.exceptions import ConnectionError
@@ -57,7 +53,7 @@ def test_create_jobs_payload():
     }
 
 
-class TestHypernovaQuery(object):
+class TestHypernovaQuery:
 
     def test_successful_send_synchronous(self, mock_fido_fetch, mock_requests_post):
         mock_requests_post.return_value.json.return_value = 'ayy lmao'

--- a/tests/token_replacement_test.py
+++ b/tests/token_replacement_test.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
-import mock
+from unittest import mock
 
 from pyramid_hypernova.rendering import RenderToken
 from pyramid_hypernova.token_replacement import hypernova_token_replacement

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -1,8 +1,5 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
+from unittest import mock
 
-import mock
 import pytest
 
 from pyramid_hypernova.rendering import RenderToken
@@ -10,7 +7,7 @@ from pyramid_hypernova.tweens import hypernova_tween_factory
 from pyramid_hypernova.types import JobResult
 
 
-class TestTweens(object):
+class TestTweens:
 
     @pytest.fixture(autouse=True)
     def mock_setup(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37,pre-commit
+envlist = py37,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
This PR drops support for Python 2.7, which has been EOL for over 2 years at this point.

Pre-commit hooks have been updated too.

This will be released as a major version.