### PR TITLE
Loop over app_iter rather than accessing response.text

### DIFF
--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from pyramid.response import Response
 
 from pyramid_hypernova.rendering import RenderToken
 from pyramid_hypernova.tweens import hypernova_tween_factory
@@ -14,9 +15,7 @@ class TestTweens:
         self.token = RenderToken('my-unique-id')
 
         mock_handler = mock.Mock()
-        mock_handler.return_value = mock.Mock(
-            text=str(self.token)
-        )
+        mock_handler.return_value = Response(text=str(self.token))
 
         self.mock_get_job_group_url = mock.Mock(return_value='http://localhost:8888/batch')
 
@@ -47,6 +46,9 @@ class TestTweens:
 
         response = self.tween(self.mock_request)
 
+        # Access the response's body to ensure the batch request is made
+        response.body
+
         self.mock_batch_request_factory.assert_called_once_with(
             get_job_group_url=self.mock_get_job_group_url,
             plugin_controller=mock.ANY,
@@ -67,6 +69,10 @@ class TestTweens:
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,
         )
+
+        # Access the response's body to ensure the batch request is made
+        response.body
+
         assert self.mock_batch_request_factory.return_value.submit.called
         assert response.text == '<div>REACT!</div>'
 
@@ -74,6 +80,9 @@ class TestTweens:
         self.mock_request.disable_hypernova_tween = True
 
         response = self.tween(self.mock_request)
+
+        # Access the response's body to ensure the batch request is made
+        response.body
 
         self.mock_batch_request_factory.assert_called_once_with(
             get_job_group_url=self.mock_get_job_group_url,
@@ -85,7 +94,7 @@ class TestTweens:
         assert response.text == str(self.token)
 
     def test_tween_returns_unmodified_response_if_no_jobs(self):
-        mock_response = mock.Mock(
+        mock_response = Response(
             body="I'm a binary file",
         )
         mock_handler = mock.Mock()
@@ -101,6 +110,9 @@ class TestTweens:
             return_value=mock_hypernova_batch,
         ):
             response = tween(self.mock_request)
+
+            # Access the response's body to ensure the batch request is made
+            response.body
 
         assert not self.mock_batch_request_factory.return_value.submit.called
         assert response == mock_response


### PR DESCRIPTION
This change is designed to prevent pyramid-hypernova from exhausting the [`app_iter` ](https://docs.pylonsproject.org/projects/pyramid/en/latest/api/response.html#pyramid.response.Response.app_iter) of the Pyramid response when it performs its token replacement logic.

For the most part [1], this should be equivalent in `Response`s that have a regular `.body` or `.text` - Pyramid will construct an `app_iter` with a single-item list containing the sole chunk:

```python
>>> from pyramid.response import Response
>>> r = Response(body=b'hello world')
>>> r.app_iter
[b'hello world']
```

In cases where `app_iter` is a generator, this will apply the token replacement per-chunk rather than loading the entire body into memory, which is useful for streamed responses.

-----

[1] "for the most part" because:

* you can see I had to update tests to deliberately access `.body` in order to trigger the behaviour under test - in theory I don't expect this to affect real apps, because at some point your response body is going to be accessed (to send to the client). If anyone can think of a real-world non-test case that this breaks, we _could_ consider checking the type of `.app_iter` rather than mapping over it (which would exactly preserve the old behaviour at the cost of more code)
* this does mean that any _cross-chunk_ information could be processed differently - but this is the responsibility of a user setting `.app_iter` to ensure that chunk boundaries make sense. It's unlikely anyone will be surprised by this behaviour if they're working with `.app_iter` directly, which is the people this change will affect