### PR TITLE
Based on request attribute, toggle surfacing more error information to client

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -22,8 +22,13 @@ def create_fallback_response(jobs, throw_client_error, json_encoder, error=None,
     return {
         identifier: JobResult(
             error=error,
-            html=render_blank_markup(identifier, job, throw_client_error,
-                                     json_encoder, (display_error_stack and error)),
+            html=render_blank_markup(
+                identifier,
+                job,
+                throw_client_error,
+                json_encoder,
+                error=error if display_error_stack else None,
+            ),
             job=job,
         )
         for identifier, job in jobs.items()
@@ -124,8 +129,8 @@ class BatchRequest:
                 )
 
                 pyramid_response = create_fallback_response(
-                    jobs, True, self.json_encoder,
-                    error, self.display_error_stack)
+                    jobs, True, self.json_encoder, error, self.display_error_stack
+                )
                 self.plugin_controller.on_error(error, jobs, self.pyramid_request)
             else:
                 pyramid_response = self._parse_response(response_json)

--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -53,7 +53,8 @@ class BatchRequest:
         plugin_controller,
         pyramid_request,
         max_batch_size=None,
-        json_encoder=JSONEncoder()
+        json_encoder=JSONEncoder(),
+        display_error_stack=False
     ):
         self.get_job_group_url = get_job_group_url
         self.jobs = {}
@@ -61,7 +62,7 @@ class BatchRequest:
         self.max_batch_size = max_batch_size
         self.json_encoder = json_encoder
         self.pyramid_request = pyramid_request
-        self.display_error_stack = False
+        self.display_error_stack = display_error_stack
 
     def render(self, name, data, context=None):
         if context is None:  # pragma: no cover
@@ -150,7 +151,6 @@ class BatchRequest:
         :rtype: Dict[str, JobResult]
         """
         self.jobs = self.plugin_controller.prepare_request(self.jobs, self.pyramid_request)
-        self.display_error_stack = getattr(self.pyramid_request, 'display_error_stack', False)
         response = {}
 
         if self.jobs and self.plugin_controller.should_send_request(self.jobs, self.pyramid_request):

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -53,10 +53,12 @@ def configure_hypernova_batch(registry, request):
     )
 
     json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', JSONEncoder())
+    should_display_error_stack = registry.settings.get('pyramid_hypernova.should_display_error_stack', None)
 
     return batch_request_factory(
         get_job_group_url=get_job_group_url,
         plugin_controller=plugin_controller,
         json_encoder=json_encoder,
         pyramid_request=request,
+        display_error_stack=should_display_error_stack(request) if should_display_error_stack else False,
     )

--- a/pyramid_hypernova/tweens.py
+++ b/pyramid_hypernova/tweens.py
@@ -53,12 +53,14 @@ def configure_hypernova_batch(registry, request):
     )
 
     json_encoder = registry.settings.get('pyramid_hypernova.json_encoder', JSONEncoder())
-    should_display_error_stack = registry.settings.get('pyramid_hypernova.should_display_error_stack', None)
+    should_display_error_stack = registry.settings.get(
+        'pyramid_hypernova.should_display_error_stack', lambda request: False
+    )
 
     return batch_request_factory(
         get_job_group_url=get_job_group_url,
         plugin_controller=plugin_controller,
         json_encoder=json_encoder,
         pyramid_request=request,
-        display_error_stack=should_display_error_stack(request) if should_display_error_stack else False,
+        display_error_stack=should_display_error_stack(request),
     )

--- a/tests/rendering_test.py
+++ b/tests/rendering_test.py
@@ -62,14 +62,14 @@ def test_render_blank_markup_with_custom_json_encoder():
     ''')
 
 
-@pytest.mark.parametrize('error, errorMarkup', [
+@pytest.mark.parametrize('error, error_markup', [
     (
         HypernovaError('Error', 'Error msg', ['1: Error', '2: stack']),
         '["Error", "Error msg", ["1: Error", "2: stack"]]'
     ),
     (None, 'undefined'),
 ])
-def test_render_blank_markup_when_throw_client_error_true(error, errorMarkup):
+def test_render_blank_markup_when_throw_client_error_true(error, error_markup):
     job = Job('MyCoolComponent.js', data={'title': 'sup'}, context={})
     markup = render_blank_markup('my-unique-token', job, True, JSONEncoder(), error)
 
@@ -94,9 +94,9 @@ def test_render_blank_markup_when_throw_client_error_true(error, errorMarkup):
                 ServerSideRenderingError.prototype = Object.create(ServerSideRenderingError.prototype);
                 ServerSideRenderingError.prototype.constructor = ServerSideRenderingError;
 
-                throw new ServerSideRenderingError('MyCoolComponentjs failed to render server-side, and fell back to client-side rendering.', {errorMarkup});
+                throw new ServerSideRenderingError('MyCoolComponentjs failed to render server-side, and fell back to client-side rendering.', {error_markup});
             }}());
         </script>
-    ''').format(errorMarkup=errorMarkup)  # noqa: ignore=E501
+    ''').format(error_markup=error_markup)  # noqa: ignore=E501
 
     assert markup == expected_markup

--- a/tests/rendering_test.py
+++ b/tests/rendering_test.py
@@ -1,9 +1,12 @@
 from json import JSONEncoder
 from textwrap import dedent
 
+import pytest
+
 from pyramid_hypernova.rendering import encode
 from pyramid_hypernova.rendering import render_blank_markup
 from pyramid_hypernova.rendering import RenderToken
+from pyramid_hypernova.types import HypernovaError
 from pyramid_hypernova.types import Job
 from testing.json_encoder import ComplexJSONEncoder
 
@@ -59,29 +62,42 @@ def test_render_blank_markup_with_custom_json_encoder():
     ''')
 
 
-def test_render_blank_markup_with_error():
+@pytest.mark.parametrize('error, errorMarkup', [
+    (
+        HypernovaError('Error', 'Error msg', ['1: Error', '2: stack']),
+        '["Error", "Error msg", ["1: Error", "2: stack"]]'
+    ),
+    (None, 'undefined'),
+])
+def test_render_blank_markup_when_throw_client_error_true(error, errorMarkup):
     job = Job('MyCoolComponent.js', data={'title': 'sup'}, context={})
-    markup = render_blank_markup('my-unique-token', job, True, JSONEncoder())
+    # error = HypernovaError('Error', 'Error msg', ['1: Error', '2: stack'])
+    markup = render_blank_markup('my-unique-token', job, True, JSONEncoder(), error)
 
-    assert markup == dedent('''
+    expected_markup = dedent('''
         <div data-hypernova-key="MyCoolComponentjs" data-hypernova-id="my-unique-token"></div>
         <script
           type="application/json"
           data-hypernova-key="MyCoolComponentjs"
           data-hypernova-id="my-unique-token"
         ><!--{"title": "sup"}--></script>
+    ''')
 
+    expected_markup += dedent('''
         <script type="text/javascript">
-            (function () {
-                function ServerSideRenderingError(component) {
+            (function () {{
+                function ServerSideRenderingError(component, error) {{
                     this.name = 'ServerSideRenderingError';
                     this.component = component;
-                }
+                    this.cause = error;
+                }}
 
                 ServerSideRenderingError.prototype = Object.create(ServerSideRenderingError.prototype);
                 ServerSideRenderingError.prototype.constructor = ServerSideRenderingError;
 
-                throw new ServerSideRenderingError('MyCoolComponentjs failed to render server-side, and fell back to client-side rendering.');
-            }());
+                throw new ServerSideRenderingError('MyCoolComponentjs failed to render server-side, and fell back to client-side rendering.', {errorMarkup});
+            }}());
         </script>
-    ''')  # noqa: ignore=E501
+    ''').format(errorMarkup=errorMarkup)  # noqa: ignore=E501
+
+    assert markup == expected_markup

--- a/tests/rendering_test.py
+++ b/tests/rendering_test.py
@@ -71,7 +71,6 @@ def test_render_blank_markup_with_custom_json_encoder():
 ])
 def test_render_blank_markup_when_throw_client_error_true(error, errorMarkup):
     job = Job('MyCoolComponent.js', data={'title': 'sup'}, context={})
-    # error = HypernovaError('Error', 'Error msg', ['1: Error', '2: stack'])
     markup = render_blank_markup('my-unique-token', job, True, JSONEncoder(), error)
 
     expected_markup = dedent('''

--- a/tests/tweens_test.py
+++ b/tests/tweens_test.py
@@ -41,6 +41,22 @@ class TestTweens:
 
         self.mock_request = mock.Mock()
 
+    def test_configure_hypernova_batch_sets_display_error_stack_value_through_function(self):
+        self.should_display_error_stack = mock.Mock(return_value=True)
+        self.mock_registry.settings['pyramid_hypernova.should_display_error_stack'] = self.should_display_error_stack
+        response = self.tween(self.mock_request)
+
+        # Access the response's body to ensure the batch request is made
+        response.body
+
+        self.mock_batch_request_factory.assert_called_once_with(
+            get_job_group_url=self.mock_get_job_group_url,
+            plugin_controller=mock.ANY,
+            json_encoder=self.mock_json_encoder,
+            pyramid_request=self.mock_request,
+            display_error_stack=True
+        )
+
     def test_tween_replaces_tokens_when_disable_hypernova_tween_not_set(self):
         del self.mock_request.disable_hypernova_tween
 
@@ -54,6 +70,7 @@ class TestTweens:
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,
+            display_error_stack=False
         )
         assert self.mock_batch_request_factory.return_value.submit.called
         assert response.text == '<div>REACT!</div>'
@@ -68,6 +85,7 @@ class TestTweens:
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,
+            display_error_stack=False
         )
 
         # Access the response's body to ensure the batch request is made
@@ -89,6 +107,7 @@ class TestTweens:
             plugin_controller=mock.ANY,
             json_encoder=self.mock_json_encoder,
             pyramid_request=self.mock_request,
+            display_error_stack=False
         )
         assert not self.mock_batch_request_factory.return_value.submit.called
         assert response.text == str(self.token)


### PR DESCRIPTION
### Issue

When the service falls back to client side rendering and logs the error, there's a lack of information as to why this has happened (missing stack trace etc) which makes it difficult to diagnose the cause. 

### Solution

Provide the ability to surface more error information if desired. It should be optional in case the information is best served to a limited audience (i.e. internal IPs).

