### PR TITLE
Allow for more error info to surface

### DIFF
--- a/tests/batch_test.py
+++ b/tests/batch_test.py
@@ -336,7 +336,14 @@ class TestBatchRequest:
         job = Job(name='MyComponent.js', data=data[0], context={})
         token = batch_request.render('MyComponent.js', data[0])
 
-        mock_hypernova_query.return_value.json.side_effect = HypernovaQueryError('oh no')
+        mock_hypernova_query.return_value.json.side_effect = HypernovaQueryError(
+            'oh no',
+            {
+                'name': 'SadError',
+                'message': 'The saddest error',
+                'stack': 'sad stack'
+            }
+        )
         response = batch_request.submit()
 
         if batch_request.max_batch_size is None:
@@ -352,9 +359,9 @@ class TestBatchRequest:
         assert response == {
             token.identifier: JobResult(
                 error=HypernovaError(
-                    name='HypernovaQueryError',
-                    message='oh no',
-                    stack=mock.ANY,
+                    name='SadError',
+                    message='The saddest error',
+                    stack='sad stack',
                 ),
                 html=render_blank_markup(token.identifier, job, True, batch_request.json_encoder),
                 job=job,


### PR DESCRIPTION
**Problem:** Some prior work was done to introduce a "cause" field to the error logged to console. This was done with the aim of being able to provide more specific information about the origins of the error. It was noted, however, that the information was limited to the boundaries of pyramid_hypernova and didn't provide much information about the origin of errors upstream. 

**Solution:** Allow upstream services the ability to pass specific error information for pyramid_hypernova to surface via name, message, stack. 

