### PR TITLE
getattr protection instead of e.error_data

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -141,7 +141,7 @@ class BatchRequest:
             __, __, exc_traceback = sys.exc_info()
             # We allow clients to send specific error data with their response that they may want to surface.
             # Check if any has been propagated, otherwise proceed with generic HypernovaError
-            if e.error_data:
+            if getattr(e, 'error_data', None) is not None:
                 error = HypernovaError(
                     name=e.error_data.name,
                     message=e.error_data.message,


### PR DESCRIPTION
e.error data will error out if error_data isn't available on the exception object (as is the case for when it's a ValueError)

used getattr instead of hasattr because we can have a HypernovaQueryError where error_data = None, so the attribute exists, we enter the condition and then we try to assign name, message, and stack (will throw error because error_data =None and not the ErrorData tuple). 