### PR TITLE
Make page checks SSR errors easier to diagnose 

### DIFF
--- a/pyramid_hypernova/rendering.py
+++ b/pyramid_hypernova/rendering.py
@@ -17,16 +17,16 @@ BLANK_MARKUP_TEMPLATE = dedent('''
 FALLBACK_ERROR = dedent('''
     <script type="text/javascript">
         (function () {{
-            function ServerSideRenderingError(component, error) {{
-                this.name = 'ServerSideRenderingError';
-                this.component = component;
-                this.cause = error;
+            class ServerSideRenderingError extends Error {{
+                constructor(component, error) {{
+                    super('{component} failed to render server-side, and fell back to client-side rendering.');
+                    this.name = 'ServerSideRenderingError';
+                    this.message = error.message;
+                    this.component = component;
+                    this.cause = error;
+                }}
             }}
-
-            ServerSideRenderingError.prototype = Object.create(ServerSideRenderingError.prototype);
-            ServerSideRenderingError.prototype.constructor = ServerSideRenderingError;
-
-            throw new ServerSideRenderingError('{component} failed to render server-side, and fell back to client-side rendering.', {error});
+            throw new ServerSideRenderingError('{component}', {error});
         }}());
     </script>
 ''')  # noqa: ignore=E501

--- a/tests/rendering_test.py
+++ b/tests/rendering_test.py
@@ -85,16 +85,16 @@ def test_render_blank_markup_when_throw_client_error_true(error, error_markup):
     expected_markup += dedent('''
         <script type="text/javascript">
             (function () {{
-                function ServerSideRenderingError(component, error) {{
-                    this.name = 'ServerSideRenderingError';
-                    this.component = component;
-                    this.cause = error;
+                class ServerSideRenderingError extends Error {{
+                    constructor(component, error) {{
+                        super('MyCoolComponentjs failed to render server-side, and fell back to client-side rendering.');
+                        this.name = 'ServerSideRenderingError';
+                        this.message = error.message;
+                        this.component = component;
+                        this.cause = error;
+                    }}
                 }}
-
-                ServerSideRenderingError.prototype = Object.create(ServerSideRenderingError.prototype);
-                ServerSideRenderingError.prototype.constructor = ServerSideRenderingError;
-
-                throw new ServerSideRenderingError('MyCoolComponentjs failed to render server-side, and fell back to client-side rendering.', {error_markup});
+                throw new ServerSideRenderingError('MyCoolComponentjs', {error_markup});
             }}());
         </script>
     ''').format(error_markup=error_markup)  # noqa: ignore=E501


### PR DESCRIPTION
## Problem or Feature
<!-- Describe the reason or rationale for this change -->
<!-- Include your Jira ticket here, if one exists! -->
Browsers often serialize and truncate objects before passing them to event handlers. Because of this, we lose information when using automation tools like Playwright which consume these events.

For example, with our current error implementation, Chromium returns the following error details
```
{
    "timestamp": 1234,
    "exceptionDetails": {
        ...
        "exception": {
            "type": "object",
            "className": "ServerSideRenderingError",
            "description": "ServerSideRenderingError",
            "preview": {
                ...
                "description": "ServerSideRenderingError",
                "properties": [
                    ...
                    {
                        "name": "component",
                        "type": "string",
                        "value": "~up to 100 characters before being truncated~"
                    },
                    {
                        "name": "cause",
                        "type": "object",
                        "value": "Object"
                    }
                ]
            }
        }
    }
}
```

## Solution
<!-- How is this problem resolved, or feature designed? -->
* Since we no longer need to support IE11 (which doesn't support the `extends` syntax), use classes to make our error more standard
* Leave both `error.component` and `error.cause` for internal use/debugging

## Verification
<!-- Describe how you verified this change works -->
<!-- Include testing of the change: Unit, integration, manual, etc -->
Updated unit test and verified manually Chromium emits events like this:
```
{
    "timestamp": 1234,
    "exceptionDetails": {
        ...
        "exception": {
            "className": "ServerSideRenderingError",
            "description": "ServerSideRenderingError: Shell failed to render, aborting SSR. Error: ReferenceError: window is not defined\n    ~full stack trace continues~",
            "preview": {
               ...
                "description": "ServerSideRenderingError: Shell failed to render, aborting SSR. Error: ReferenceError: window is not defined\n    ~full stack trace continues~",
                "properties": [
                    ...
                    {
                        "name": "name",
                        "type": "string",
                        "value": "ServerSideRenderingError"
                    },
                    {
                        "name": "component",
                        "type": "string",
                        "value": "~up to 100 characters before being truncated~"
                    },
                    {
                        "name": "cause",
                        "type": "object",
                        "value": "Object"
                    }
                ]
            }
        }
    }
}
```
