### PR TITLE
drop support for python < 3.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout Repo
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.10
 
     - name: Install Python dependencies
       run: pip install wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.3.0
+      rev: v5.0.0
       hooks:
           - id: trailing-whitespace
           - id: end-of-file-fixer
@@ -15,19 +15,19 @@ repos:
             exclude: ^\.activate\.sh$
           - id: check-byte-order-marker
     - repo: https://github.com/pre-commit/mirrors-autopep8
-      rev: v1.7.0
+      rev: v2.0.4
       hooks:
           - id: autopep8
     - repo: https://github.com/PyCQA/flake8
-      rev: 5.0.4
+      rev: 7.3.0
       hooks:
           - id: flake8
     - repo: https://github.com/asottile/reorder_python_imports
-      rev: v3.8.2
+      rev: v3.15.0
       hooks:
           - id: reorder-python-imports
     - repo: https://github.com/asottile/pyupgrade
-      rev: v2.37.3
+      rev: v3.20.0
       hooks:
           - id: pyupgrade
-            args: ['--py37-plus']
+            args: ['--py310-plus']

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
     description="A Python client for Airbnb's Hypernova server, for use with the Pyramid web framework.",
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.10',
         'License :: OSI Approved :: MIT License',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.10',
     install_requires=[
         'fido',
         'more-itertools',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,pre-commit
+envlist = py310,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -10,13 +10,13 @@ commands =
     coverage report --fail-under 100
 
 [testenv:pre-commit]
-basepython = python3.7
+basepython = python3.10
 commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 
 [testenv:venv]
-basepython = python3.7
+basepython = python3.10
 envdir = venv
 commands =
 


### PR DESCRIPTION
The [Github Action for publishing to pypi](https://github.com/Yelp/pyramid-hypernova/actions/runs/15862609671/job/44723075163) failed after merging https://github.com/Yelp/pyramid-hypernova/pull/41 and attempting to push tags for the new version. Looking at the manifest, there is no match for the combination of ubuntu at "latest" (24.04), python at 3.7, and arch x64.

An alternative to this would be to downpin ubuntu in the Github workflow but this seems preferable, py39 is EOL in 4 months.