### PR TITLE
put python-version in quotes in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
 
     - name: Install Python dependencies
       run: pip install wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.0.1] - 2025-06-25
+
+### Changed
+Fix Github Workflow yaml by putting python-version in quotes ("3.10" reads as "3.1" without them)
+
 ## [10.0.0] - 2025-06-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.0.1] - 2025-06-25
 
 ### Changed
-Fix Github Workflow yaml by putting python-version in quotes ("3.10" reads as "3.1" without them)
+Fix GitHub Workflow yaml by putting python-version in quotes ("3.10" reads as "3.1" without them)
 
 ## [10.0.0] - 2025-06-25
 


### PR DESCRIPTION
Publish to pypi failed again because the yaml 3.10 gets parsed as 3.1 without quotes: https://github.com/Yelp/pyramid-hypernova/actions/runs/15887901749