### PR TITLE
Fix crash caused by a JSONDecodeError

### DIFF
--- a/pyramid_hypernova/batch.py
+++ b/pyramid_hypernova/batch.py
@@ -7,6 +7,7 @@ from more_itertools import chunked
 
 from pyramid_hypernova.rendering import render_blank_markup
 from pyramid_hypernova.rendering import RenderToken
+from pyramid_hypernova.request import ErrorData
 from pyramid_hypernova.request import HypernovaQuery
 from pyramid_hypernova.request import HypernovaQueryError
 from pyramid_hypernova.types import HypernovaError
@@ -141,7 +142,7 @@ class BatchRequest:
             __, __, exc_traceback = sys.exc_info()
             # We allow clients to send specific error data with their response that they may want to surface.
             # Check if any has been propagated, otherwise proceed with generic HypernovaError
-            if getattr(e, 'error_data', None) is not None:
+            if isinstance(getattr(e, 'error_data', None), ErrorData):
                 error = HypernovaError(
                     name=e.error_data.name,
                     message=e.error_data.message,

--- a/pyramid_hypernova/request.py
+++ b/pyramid_hypernova/request.py
@@ -101,7 +101,9 @@ class HypernovaQuery:
                     response_error_data = self.response.json().get('error', None)
                     error_data = format_response_error_data(response_error_data)
                 except JSONDecodeError:
-                    error_data = self.response.text or 'No response data'
+                    error_data = format_response_error_data({
+                        'message': self.response.text or 'SSRS did not return any content',
+                    })
 
                 raise HypernovaQueryError(e, error_data)
             except ConnectionError as e:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='pyramid-hypernova',
-    version='10.0.1',
+    version='10.0.2',
     author='Yelp, Inc.',
     author_email='opensource+pyramid-hypernova@yelp.com',
     license='MIT',

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -127,6 +127,7 @@ class TestHypernovaQuery:
         )
         assert str(exc_info.value) == str(HypernovaQueryError(HTTPError('ayy lmao')))
         assert isinstance(exc_info.value.error_data, ErrorData)
+        assert exc_info.value.error_data.message == 'Non-JSON Error Body'
 
     def test_successful_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
         mock_fido_fetch.return_value.wait.return_value.code = 200

--- a/tests/request_test.py
+++ b/tests/request_test.py
@@ -126,7 +126,7 @@ class TestHypernovaQuery:
             data=mock.ANY,
         )
         assert str(exc_info.value) == str(HypernovaQueryError(HTTPError('ayy lmao')))
-        assert exc_info.value.error_data == 'Non-JSON Error Body'
+        assert isinstance(exc_info.value.error_data, ErrorData)
 
     def test_successful_send_asynchronous(self, mock_fido_fetch, mock_requests_post):
         mock_fido_fetch.return_value.wait.return_value.code = 200


### PR DESCRIPTION
#41 caught `JSONDecodeError`s, but replaced them with a `HypernovaQueryError` that had its `error_data` set to a string instead of an `ErrorData` namedtuple. `process_responses` caught this error and attempted to read `error_data.name`, which relies on `error_data` being an `ErrorData` instance. this was not the case, and we instead raised an uncaught `AttributeError`.

this PR both ensures that the `HypernovaQueryError` raised in response to the `JSONDecodeError` has a valid `error_data` field and that `process_responses` gracefully handles `HypernovaQueryError`s that don't have valid `error_data` fields.

type checking would've caught this, but since we're actively working on removing Hypernova from our stack, it doesn't make sense to spend the time to add it here.